### PR TITLE
feature/42-chokidar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -806,6 +806,21 @@
                 "node": "18 || 20 || >=22"
             }
         },
+        "node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/diff": {
             "version": "8.0.3",
             "license": "BSD-3-Clause",
@@ -1022,6 +1037,19 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/require-from-string": {
@@ -1390,6 +1418,7 @@
                 "@papit/html": "0.0.1",
                 "@papit/information": "0.0.1",
                 "@papit/terminal": "0.0.1",
+                "chokidar": "^5.0.0",
                 "esbuild": "0.27.2"
             },
             "bin": {

--- a/packages/runtime/cli/build/src/index.ts
+++ b/packages/runtime/cli/build/src/index.ts
@@ -6,7 +6,7 @@ import { type LogLevel } from "esbuild";
 import { Information, PackageNode } from "@papit/information";
 import { Args, Arguments } from "@papit/arguments";
 import { Terminal } from "@papit/terminal";
-import { getESOptions, hasChanged, jsBundle, jsWatch, OnBuildEvent } from "@papit/bundle-js";
+import { getESOptions, hasChanged, jsBundle, OnBuildEvent } from "@papit/bundle-js";
 import { tsBundle } from "@papit/bundle-ts";
 
 import { npmInstall } from "helper";
@@ -15,50 +15,19 @@ function canPrint() {
     return Arguments.has("run-build") || (Arguments.isCLI && !!process.env._?.endsWith("papit-build"));
 }
 
-// function runBatch(batch: PackageNode[], failed: Set<string>, args: Args, canprint: boolean) {
-//     const promises = batch.map(node => runner(node, failed, args, canprint));
-//     return Promise.all(promises);
-// }
-
-export function debounceFn<T extends (...args: any[]) => any>(
-    execute: T,
-    delay: number = 100
-): (...args: Parameters<T>) => void {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-
-    return function (this: ThisParameterType<T>, ...args: Parameters<T>) {
-        if (timer)
-        {
-            clearTimeout(timer);
-        }
-
-        timer = setTimeout(() => {
-            execute.apply(this, args);
-            timer = null;
-        }, delay);
-    };
-}
-
 (async function () {
 
     if (!canPrint()) return;
-    const watchers = await build();
-
-    await new Promise<void>(resolve => {
-        process.on("SIGINT", async () => {
-            Terminal.write("\ndisposing watchers...");
-            await Promise.all(watchers.map(w => w.dispose()));
-            resolve();
-        });
-    });
+    await build();
 }())
 
 export async function build(
     args = new Args(process.argv),
-    onPackageBuild?: (node: PackageNode, info: OnBuildEvent) => void,
+    node?: PackageNode,
+    onPackageBuild?: (node: PackageNode, info: "failed" | "skipped" | "success") => void,
 ) {
     const canprint = canPrint();
-    const ordered = Information.getPriorityBatches(args);
+    const failed = new Set<string>();
 
     let logLevel: LogLevel = "silent";
     if (args.error) logLevel = "error";
@@ -66,11 +35,23 @@ export async function build(
     else if (args.info) logLevel = "info";
     else if (args.verbose || args.debug) logLevel = "info";
 
-    const failed = new Set<string>();
-    const watchers: Awaited<ReturnType<typeof jsWatch>>[] = [];
-    let hasprintedPriority = false;
+    if (node)
+    {
+        if (node.packageJSON.papit?.type === "theme")
+        {
+            const result = buildTheme(args, node);
+            if (onPackageBuild) onPackageBuild(node, result);
+            return;
+        }
 
-    const debouncedInstall = debounceFn(npmInstall);
+        const shouldinstall = await runner(node, failed, args, canprint, logLevel, onPackageBuild);
+        if (shouldinstall) await npmInstall(args, canprint);
+        return;
+    }
+
+    const ordered = Information.getPriorityBatches(args);
+
+    let hasprintedPriority = false;
 
     // always do initial build first, in order
     for (const batch of ordered)
@@ -100,70 +81,12 @@ export async function build(
                 }
                 continue;
             }
-            const install = await runner(node, failed, args, canprint, logLevel);
+            const install = await runner(node, failed, args, canprint, logLevel, onPackageBuild);
             if (install) shouldinstall = true;
         }
 
         if (shouldinstall) await npmInstall(args, canprint);
     }
-
-
-    // after initial build, start watchers if live
-    if (args.has("live"))
-    {
-        for (const batch of ordered)
-        {
-            for (const node of batch)
-            {
-                if (failed.has(node.name)) continue;
-                if (node.packageJSON.papit?.type === "theme") 
-                {
-                    buildTheme(args, node);
-                    continue;
-                }
-
-                const baseOptions = getESOptions(Arguments.instance, node.location, {
-                    logLevel,
-                    packageJSON: node.packageJSON,
-                    externals: node.externals,
-                });
-                const watcher = await jsWatch(
-                    args, node.location,
-                    {
-                        entryPoints: node.entrypoints,
-                        logLevel,
-                        externals: node.externals,
-                        packageJSON: node.packageJSON,
-                        tsconfig: node.tsconfig,
-                        esoptions: baseOptions,
-                    },
-                    async (info) => {
-                        const shouldinstall = onBuild(args, node, info);
-
-                        onPackageBuild?.(node, info);
-                        if (node.tsconfig.options.declaration)
-                        {
-                            await tsBundle(args, node.location, {
-                                entryPoints: node.entrypoints,
-                                packageJSON: node.packageJSON,
-                                tsconfig: node.tsconfig,
-                            });
-                        }
-
-                        if (shouldinstall)
-                        {
-                            debouncedInstall(args, canprint);
-                        }
-                    }
-                );
-                watchers.push(watcher);
-            }
-        }
-
-        if (canprint) Terminal.write(Terminal.green("watching..."));
-    }
-
-    return watchers;
 }
 
 async function runner(
@@ -172,6 +95,7 @@ async function runner(
     args: Args,
     canprint: boolean,
     logLevel: LogLevel,
+    onPackageBuild?: (node: PackageNode, info: "failed" | "skipped" | "success") => void,
 ): Promise<boolean> {
     // we store terminal functions for the loading
     let close: () => void = () => null;
@@ -248,6 +172,15 @@ async function runner(
             }
         }
 
+        if (skipped.bundlejs || skipped.bundlets)
+        {
+            onPackageBuild?.(node, "skipped");
+        }
+        else
+        {
+            onPackageBuild?.(node, "success");
+        }
+
         if (canprint) 
         {
             close(); // cool
@@ -275,6 +208,7 @@ async function runner(
             }
         }
 
+        onPackageBuild?.(node, "failed");
         failed.add(node.name);
     }
     finally 
@@ -303,7 +237,7 @@ function buildTheme(args: Args, node: PackageNode) {
 }
 
 function onBuild(args: Args, node: PackageNode, info: OnBuildEvent) {
-    if (info.type !== "build" && info.type !== "rebuild") return;
+    if (info.type !== "build") return; // && info.type !== "rebuild") return;
 
     const importOutput = info.entry.output ?? "";
     const binName = node.entrypoints.bin.get(importOutput);

--- a/packages/runtime/cli/bundle-js/src/bundler.ts
+++ b/packages/runtime/cli/bundle-js/src/bundler.ts
@@ -1,7 +1,7 @@
 // import statements
 import fs from "node:fs";
 import path from "node:path";
-import esbuild, { BuildContext, type BuildOptions, type BuildResult } from "esbuild";
+import esbuild, { type BuildOptions, type BuildResult } from "esbuild";
 import { getESOptions, modifyOptions, type Options } from "./options";
 import { hasChanged } from "changed";
 import { getEntryPoints } from "entrypoints";
@@ -19,7 +19,7 @@ function timestamp(args: { has: (key: string) => boolean }, message?: string) {
 }
 
 export type OnBuildEvent =
-    | { type: "build" | "rebuild"; result: esbuild.BuildResult<esbuild.BuildOptions>; entry: { input: string, output: string | undefined } }
+    | { type: "build"; result: esbuild.BuildResult<esbuild.BuildOptions>; entry: { input: string, output: string | undefined } }
     | { type: "skipped" };
 
 type OnBuild = (event: OnBuildEvent) => void;
@@ -80,53 +80,53 @@ export async function jsBundle(
 }
 
 
-export async function jsWatch(
-    args: { has: (key: string) => boolean },
-    location: string,
-    options?: Partial<Options>,
-    onBuild?: OnBuild,
-): Promise<{ contexts: BuildContext[], dispose: () => void }> {
+// export async function jsWatch(
+//     args: { has: (key: string) => boolean },
+//     location: string,
+//     options?: Partial<Options>,
+//     onBuild?: OnBuild,
+// ): Promise<{ contexts: BuildContext[], dispose: () => void }> {
 
-    const tsconfig = options?.tsconfig ?? getTSconfig(args, location);
-    const packageJsonLocation = path.join(location, "package.json");
-    if (!fs.existsSync(packageJsonLocation)) throw new Error("[@papit/bundle-js] error no package.json file found");
+//     const tsconfig = options?.tsconfig ?? getTSconfig(args, location);
+//     const packageJsonLocation = path.join(location, "package.json");
+//     if (!fs.existsSync(packageJsonLocation)) throw new Error("[@papit/bundle-js] error no package.json file found");
 
-    const packageJSON: PackageJson = options?.packageJSON ?? JSON.parse(fs.readFileSync(packageJsonLocation, { encoding: "utf-8" }));
-    const entryPoints = options?.entryPoints ?? getEntryPoints(location, packageJSON, tsconfig);
-    const entrypointsArray = options?.entryPointArray ? options.entryPointArray : Object.values(entryPoints.entries).map(value => value.import).filter(v => v !== undefined);
-    const first = entrypointsArray.at(0);
+//     const packageJSON: PackageJson = options?.packageJSON ?? JSON.parse(fs.readFileSync(packageJsonLocation, { encoding: "utf-8" }));
+//     const entryPoints = options?.entryPoints ?? getEntryPoints(location, packageJSON, tsconfig);
+//     const entrypointsArray = options?.entryPointArray ? options.entryPointArray : Object.values(entryPoints.entries).map(value => value.import).filter(v => v !== undefined);
+//     const first = entrypointsArray.at(0);
 
-    if (!first) throw new Error("[@papit/bundle-js] no entry-points passed");
+//     if (!first) throw new Error("[@papit/bundle-js] no entry-points passed");
 
-    const esoptions = options?.esoptions ?? getESOptions(args, location, options);
+//     const esoptions = options?.esoptions ?? getESOptions(args, location, options);
 
-    const entrySet = new Set<string>();
+//     const entrySet = new Set<string>();
 
-    const contexts = await Promise.all(
-        entrypointsArray.map(async entry => {
-            const option = modifyOptions(entry, esoptions);
-            const ctx = await esbuild.context({
-                ...option,
-                plugins: [
-                    ...(option.plugins ?? []),
-                    {
-                        name: "onbuild",
-                        setup(build) {
-                            build.onEnd(result => {
-                                if (onBuild) onBuild({ type: entrySet.has(entry.input) ? "rebuild" : "build", result, entry });
-                                entrySet.add(entry.input);
-                            });
-                        }
-                    }
-                ]
-            });
-            await ctx.watch();
-            return ctx;
-        })
-    );
+//     const contexts = await Promise.all(
+//         entrypointsArray.map(async entry => {
+//             const option = modifyOptions(entry, esoptions);
+//             const ctx = await esbuild.context({
+//                 ...option,
+//                 plugins: [
+//                     ...(option.plugins ?? []),
+//                     {
+//                         name: "onbuild",
+//                         setup(build) {
+//                             build.onEnd(result => {
+//                                 if (onBuild) onBuild({ type: entrySet.has(entry.input) ? "rebuild" : "build", result, entry });
+//                                 entrySet.add(entry.input);
+//                             });
+//                         }
+//                     }
+//                 ]
+//             });
+//             await ctx.watch();
+//             return ctx;
+//         })
+//     );
 
-    return {
-        contexts,
-        dispose: () => Promise.all(contexts.map(ctx => ctx.dispose())),
-    };
-}
+//     return {
+//         contexts,
+//         dispose: () => Promise.all(contexts.map(ctx => ctx.dispose())),
+//     };
+// }

--- a/packages/runtime/cli/server/asset/templates/live/main.js
+++ b/packages/runtime/cli/server/asset/templates/live/main.js
@@ -6,6 +6,8 @@ window.addEventListener("load", function () {
     }
     ws.onopen = () => {
         console.log('live-server socket connected', 'ws://localhost:' + location.port ?? window.PAPIT_PORT);
+
+        ws.send(JSON.stringify({type: "register", location: window.location.pathname}));
     }
     ws.onmessage = (message) => {
         const data = JSON.parse(message.data); // { action: 'update', filename, content }
@@ -14,10 +16,10 @@ window.addEventListener("load", function () {
         {
             case "update":
                 // NOTE: this might need to be expanded since this wont upgrade whenever 
-                if (window.location.pathname.startsWith(data.filename) || data.filename.startsWith(window.location.pathname))
+                if (data.isDescendant || window.location.pathname.startsWith(data.filename) || data.filename.startsWith(window.location.pathname))
                     window.location.reload();
                 else
-                    console.log("hot reload skipped", { filename: data.filename, window: window.location.pathname })
+                    console.log("hot reload skipped", {filename: data.filename, window: window.location.pathname})
                 break;
             case "error":
                 console.log('wonk wonk an error..');

--- a/packages/runtime/cli/server/package.json
+++ b/packages/runtime/cli/server/package.json
@@ -62,6 +62,7 @@
         "@papit/html": "0.0.1",
         "@papit/information": "0.0.1",
         "@papit/terminal": "0.0.1",
+        "chokidar": "^5.0.0",
         "esbuild": "0.27.2"
     },
     "devDependencies": {

--- a/packages/runtime/cli/server/src/components/file/bundler.ts
+++ b/packages/runtime/cli/server/src/components/file/bundler.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 
-import { jsBundle, jsWatch } from "@papit/bundle-js";
+import { jsBundle } from "@papit/bundle-js";
 import { Arguments } from "@papit/arguments";
 
 import { getPACKAGE, getURL } from "components/http/url";
@@ -10,37 +10,37 @@ import { NotFoundError } from "components/errors";
 import { Cache } from "./cache";
 import { FileConstants } from "./types";
 
-const watchContexts = new Map<string, Awaited<ReturnType<typeof jsWatch>>>();
+// const watchContexts = new Map<string, Awaited<ReturnType<typeof jsWatch>>>();
 
 export async function bundler(url: ReturnType<typeof getURL>, cache: Cache) {
     const node = getPACKAGE(url);
 
     //  && !Arguments.has("serve")
-    if (!Arguments.has("prod") && !watchContexts.has(url.absolute))
-    {
-        // const watcher = await jsWatch(
-        //     Arguments.instance,
-        //     node.location,
-        //     {
-        //         entryPointArray: [{ input: url.absolute, output: undefined }],
-        //         tsconfig: node?.tsconfig,
-        //         externals: node?.externals,
-        //         packageJSON: node?.packageJSON,
-        //         esoptions: { write: false },
-        //     },
-        //     (info) => {
-        //         if (info.type !== "build" && info.type !== "rebuild") return;
-        //         if (info.result.errors.length > 0) return void error(url.absolute, info.result.errors);
-        //         const content = info.result.outputFiles?.at(0)?.text;
-        //         if (content)
-        //         {
-        //             cache.add(url, Buffer.from(content, "utf8"), FileConstants.MimeTypes[".js"], null);
-        //             update(url.absolute, "");
-        //         }
-        //     }
-        // );
-        // watchContexts.set(url.absolute, watcher);
-    }
+    // if (!Arguments.has("prod") && !watchContexts.has(url.absolute))
+    // {
+    // const watcher = await jsWatch(
+    //     Arguments.instance,
+    //     node.location,
+    //     {
+    //         entryPointArray: [{ input: url.absolute, output: undefined }],
+    //         tsconfig: node?.tsconfig,
+    //         externals: node?.externals,
+    //         packageJSON: node?.packageJSON,
+    //         esoptions: { write: false },
+    //     },
+    //     (info) => {
+    //         if (info.type !== "build" && info.type !== "rebuild") return;
+    //         if (info.result.errors.length > 0) return void error(url.absolute, info.result.errors);
+    //         const content = info.result.outputFiles?.at(0)?.text;
+    //         if (content)
+    //         {
+    //             cache.add(url, Buffer.from(content, "utf8"), FileConstants.MimeTypes[".js"], null);
+    //             update(url.absolute, "");
+    //         }
+    //     }
+    // );
+    // watchContexts.set(url.absolute, watcher);
+    // }
 
     // initial bundle (or non-live)
     let content: string | undefined;

--- a/packages/runtime/cli/server/src/components/http/server.ts
+++ b/packages/runtime/cli/server/src/components/http/server.ts
@@ -2,8 +2,9 @@
 import http, { ServerResponse } from "node:http";
 import fs from "node:fs";
 import path from "node:path";
+import chokidar from "chokidar";
 
-import { Information } from "@papit/information";
+import { Information, PackageNode } from "@papit/information";
 import { Arguments } from "@papit/arguments";
 import { Terminal } from "@papit/terminal";
 
@@ -17,9 +18,10 @@ import { bundler } from "components/file/bundler";
 import { Cache } from "components/file/cache";
 import { getFILE } from "components/file/get";
 
-import { upgrade } from "./socket";
+import { update as socketUpdate, upgrade } from "./socket";
 import { getPort } from "./port";
-import { getURL } from "./url";
+import { getPACKAGE, getURL } from "./url";
+import { build } from "@papit/build";
 
 let PORT = Arguments.number("port") || 3000;
 export let server: null | http.Server = null;
@@ -31,7 +33,8 @@ export function start(
     importmap: { imports: Record<string, string> },
     themes: Map<string, string>,
 ) {
-    PORT = Arguments.number("port") || 3000
+    PORT = Arguments.number("port") || 3000;
+
     return new Promise<void>(async (resolve) => {
 
         PORT = await getPort(PORT);
@@ -45,6 +48,9 @@ export function start(
         const bundlecache = new Cache("bundle");
         bundlecache.maxSize = Arguments.number("cache-bundle") ?? 150; // MB
 
+
+        if (!Arguments.has("prod")) live();
+
         if (Information.packageName !== "@papit/server" && !Arguments.has("serve"))
         {
             if (Arguments.info) Terminal.write(Terminal.blue("listening to file changes"), Information.package.name);
@@ -54,12 +60,6 @@ export function start(
             Arguments.set("location", Information.package.location);
             Arguments.set("mode", "dev");
             Arguments.set("buildMode", "ancestors");
-
-            // executor({
-            //     callback(counter, result) {
-            //         console.log('rebuild')
-            //     },
-            // });
         }
 
         server.listen(PORT, () => {
@@ -234,4 +234,86 @@ function handleError(e: unknown, res: ServerResponse) {
     }
 
     res.end();
+}
+
+function live() {
+    const watcher = chokidar.watch(Information.root.location, {
+        ignored: (filePath: string) => {
+            return (
+                filePath.includes("/node_modules/") ||
+                filePath.includes("/.temp/") ||
+                filePath.includes("/.vscode/") ||
+                filePath.includes("/.github/") ||
+                filePath.includes("/lib/")
+            );
+        },
+        // ignoreInitial: true, // BUG IN CHOKIDAR WITH "followSymlinks"
+        persistent: true,
+        followSymlinks: false
+    });
+
+    let chokidarready = false;
+    watcher.on("ready", () => { chokidarready = true; });
+
+    let isBuilding = false;
+
+    const runBuild = async (node: PackageNode) => {
+        isBuilding = true;
+        try
+        {
+            await build(Arguments.instance, node, (_, info) => {
+                if (info === "success")
+                {
+                    if (Arguments.info) Terminal.write(Terminal.blue("rebuilt"), node.name);
+                    socketUpdate(node);
+                }
+                else if (info === "skipped")
+                {
+                    if (Arguments.info) Terminal.write(Terminal.blue("skipped"), node.name);
+                }
+                else 
+                {
+                    if (Arguments.info) Terminal.error(node.name);
+                }
+            });
+        }
+        catch (e)
+        {
+            if (Arguments.error) Terminal.error(e);
+        }
+        finally 
+        {
+            isBuilding = false;
+        }
+    }
+
+    watcher.on("all", (event, filePath, stats) => {
+        if (!chokidarready) return;
+        if (isBuilding) return;
+
+        const url = { absolute: filePath, relative: path.relative(Information.root.location, filePath) };
+        const packageNode = getPACKAGE(url);
+
+        if (url.relative.includes(packageNode.sourceFolder + "/"))
+        {
+            runBuild(packageNode);
+        }
+        else 
+        {
+            socketUpdate(packageNode);
+        }
+
+        if (Arguments.debug)
+        {
+            console.log("SERVER LIVE RELOAD", {
+                url,
+                package: {
+                    name: packageNode.name,
+                    location: packageNode.location,
+                    src: packageNode.sourceFolder,
+                },
+                includes: url.relative.includes(packageNode.sourceFolder + "/")
+            })
+        }
+    });
 }

--- a/packages/runtime/cli/server/src/components/http/socket.ts
+++ b/packages/runtime/cli/server/src/components/http/socket.ts
@@ -5,9 +5,10 @@ import path from "node:path";
 
 import { Arguments } from "@papit/arguments";
 import { Terminal } from "@papit/terminal";
-import { Information } from "@papit/information";
+import { Information, PackageNode } from "@papit/information";
+import { getPACKAGE } from "./url";
 
-const connectedClients = new Set<Duplex>();
+const connectedClients = new Map<Duplex, PackageNode>();
 
 export function upgrade(this: http.Server, req: http.IncomingMessage, socket: Duplex, head: Buffer) {
     // handshake
@@ -24,7 +25,7 @@ export function upgrade(this: http.Server, req: http.IncomingMessage, socket: Du
     socket.write(responseHeaders.join('\r\n') + '\r\n\r\n');
 
     // keeping track
-    connectedClients.add(socket);
+
 
     if (Arguments.info) Terminal.write(Terminal.blue("client connected"));
 
@@ -34,10 +35,56 @@ export function upgrade(this: http.Server, req: http.IncomingMessage, socket: Du
     socket.on("error", (err: any) => {
         if (err.code === "ECONNRESET") connectedClients.delete(socket);
     });
+    socket.on("data", (chunk: Buffer) => {
+        try
+        {
+            const frame = parseWebSocketFrame(chunk);
+
+            switch (frame.opcode)
+            {
+                case 0x1: // text frame
+                    const message = frame.payload.toString('utf8');
+                    // Parse as JSON if that's what you're sending
+                    try
+                    {
+                        const data = JSON.parse(message);
+
+                        switch (data.type)
+                        {
+                            case "register": {
+                                const packageNode = getPACKAGE({ relative: data.location, absolute: path.join(Information.root.location, data.location) });
+                                connectedClients.set(socket, packageNode);
+                                break;
+                            }
+                        }
+
+                    }
+                    catch (e) { }
+                    break;
+
+                case 0x8: // close frame
+                    console.log('Client requested close');
+                    socket.end();
+                    break;
+
+                case 0x9: // ping
+                    // Send pong back
+                    const pongFrame = frameWebSocketMessage({ type: 'pong' });
+                    socket.write(pongFrame);
+                    break;
+
+                default:
+                    console.log('Unknown opcode:', frame.opcode);
+            }
+        } catch (err)
+        {
+            console.error('Error parsing WebSocket frame:', err);
+        }
+    });
 }
 
 // exposed functions 
-export function update(filename: string, content: string) {
+export function update(node: PackageNode) {
     // notify all clients 
     try
     {
@@ -47,8 +94,23 @@ export function update(filename: string, content: string) {
             return
         }
 
-        const message = frameWebSocketMessage({ action: 'update', filename: "/" + path.relative(Information.root.location, filename), content });
-        write(message);
+        const rawMessage = {
+            action: "update",
+            filename: "/" + path.relative(Information.root.location, node.location),
+        }
+
+        connectedClients.forEach((socketNode, socket) => {
+
+            if (!socket || !socket.writable)
+            {
+                if (Arguments.verbose) Terminal.error(Terminal.blue("socket"), "[error] could not find client");
+                connectedClients.delete(socket);
+                return;
+            }
+            const message = frameWebSocketMessage({ ...rawMessage, isDescendant: node?.descendants.some(n => n.name === socketNode.name) });
+
+            socket.write(message);
+        });
     }
     catch (e)
     {
@@ -69,7 +131,8 @@ export function error(filename: string, errors: any[]) {
 
 // helper functions
 function write(message: Buffer<ArrayBufferLike>) {
-    connectedClients.forEach((socket) => {
+    connectedClients.forEach((_, socket) => {
+
         if (!socket || !socket.writable)
         {
             if (Arguments.verbose) Terminal.error(Terminal.blue("socket"), "[error] could not find client");
@@ -115,4 +178,51 @@ function frameWebSocketMessage(data: unknown): Buffer {
     payload.copy(frame, offset);
 
     return frame;
+}
+
+function parseWebSocketFrame(buffer: Buffer): { opcode: number; payload: Buffer } {
+    const firstByte = buffer[0];
+    const secondByte = buffer[1];
+
+    const fin = (firstByte & 0x80) !== 0;
+    const opcode = firstByte & 0x0f;
+    const masked = (secondByte & 0x80) !== 0;
+    let payloadLength = secondByte & 0x7f;
+
+    let offset = 2;
+
+    // Extended payload length (matches your framing logic)
+    if (payloadLength === 126)
+    {
+        payloadLength = buffer.readUInt16BE(offset);
+        offset += 2;
+    } else if (payloadLength === 127)
+    {
+        payloadLength = Number(buffer.readBigUInt64BE(offset));
+        offset += 8;
+    }
+
+    // Clients MUST mask payload, so we expect masked = true
+    if (!masked)
+    {
+        throw new Error("Expected masked frame from client");
+    }
+
+    // Read masking key
+    const maskingKey = buffer.slice(offset, offset + 4);
+    offset += 4;
+
+    // Read and unmask payload
+    const maskedPayload = buffer.slice(offset, offset + payloadLength);
+    const unmasked = Buffer.alloc(payloadLength);
+
+    for (let i = 0; i < payloadLength; i++)
+    {
+        unmasked[i] = maskedPayload[i] ^ maskingKey[i % 4];
+    }
+
+    return {
+        opcode,
+        payload: unmasked
+    };
 }

--- a/packages/runtime/cli/server/src/index.ts
+++ b/packages/runtime/cli/server/src/index.ts
@@ -3,10 +3,9 @@ import fs from "node:fs";
 import { Arguments } from "@papit/arguments";
 import { Terminal } from "@papit/terminal";
 import { Information } from "@papit/information";
-import { build } from "@papit/build";
 
 import { extractAssets, getAssetFolders, Translations } from "components/asset";
-import { close as httpExit, start as httpStart, update as socketUpdate } from "components/http";
+import { close as httpExit, start as httpStart } from "components/http";
 import type { Importmap } from "components/importmap/types";
 import { extractImportmap } from "components/importmap/import-map";
 import { getPackageLocationFromImportMeta } from "components/http/url";
@@ -119,13 +118,14 @@ export async function setup() {
 
     // if (!Arguments.has("prod") && !Arguments.has("serve")) Arguments.set("live", true);
 
-    const buildOutput = await build(Arguments.instance, (node, info) => {
-        if (info.type === "rebuild")
-        {
-            if (Arguments.verbose) Terminal.write(Terminal.blue("package change"), node.name)
-            socketUpdate(node.location, info.result.outputFiles?.at(0)?.text ?? "");
-        }
-    });
+    // const buildOutput = await build(Arguments.instance, (node, info) => {
+    //     if (info.type === "rebuild")
+    //     {
+    //         if (Arguments.verbose) Terminal.write(Terminal.blue("package change"), node.name)
+    //         socketUpdate(node.location, info.result.outputFiles?.at(0)?.text ?? "");
+    //     }
+    // }); //
+
 
     const shutdown = () => {
         if (importmapFolder && createdImportMapFolder && !Arguments.has("import-map"))
@@ -133,7 +133,7 @@ export async function setup() {
             fs.rmSync(path.join(Information.package.location, ".temp"), { force: true, recursive: true });
         }
 
-        buildOutput.forEach(output => output.dispose());
+        // buildOutput.forEach(output => output.dispose());
 
         console.log(); // spacing for Ctrl+C
         httpExit();


### PR DESCRIPTION
issue: #42 

note: this PR makes sure the server is equipped with live reload, more stronger then last which was using the esbuild watch - but that had CPU issues due to several watching accounts. The new way uses chokidar instead and can also deal with descendants as a socket will now register itself. note: update will not care if it came from asset update or not, so we might miss some asset cases or overshoot in other. But it will be good enough.

changelog:
- fix: chokidar support

- fix: selective updates