### PR TITLE
bugfix/69-publish-remote-version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         env:
           CI: true
-        run: npm run build -- --ci --run-build
+        run: npm run build -- --ci --run-build --remote
 
       - name: Publish to npmjs.com
         run: npm run publish -- --ci ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build
         env: 
           CI: true
-        run: npm run build -- --ci --run-build
+        run: npm run build -- --ci --run-build --remote
 
       # Long-lived Playwright cache (read-only in PRs)
       - name: Restore Playwright cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1371,7 +1371,7 @@
                 "@papit/bundle-js": "0.0.2",
                 "@papit/bundle-ts": "0.0.1",
                 "@papit/data-structure": "0.0.1",
-                "@papit/information": "0.0.4",
+                "@papit/information": "0.0.3",
                 "@papit/terminal": "0.0.1"
             },
             "bin": {
@@ -1426,11 +1426,11 @@
         },
         "packages/runtime/cli/create": {
             "name": "@papit/create",
-            "version": "0.0.4",
+            "version": "0.0.3",
             "license": "Papit-1.0",
             "dependencies": {
                 "@papit/arguments": "0.0.1",
-                "@papit/information": "0.0.4",
+                "@papit/information": "0.0.3",
                 "@papit/terminal": "0.0.1"
             },
             "bin": {
@@ -1446,7 +1446,7 @@
         },
         "packages/runtime/cli/information": {
             "name": "@papit/information",
-            "version": "0.0.4",
+            "version": "0.0.3",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
                 "@papit/arguments": "0.0.1",
@@ -1473,7 +1473,7 @@
                 "@papit/bundle-js": "0.0.2",
                 "@papit/deep-merge": "0.0.1",
                 "@papit/html": "0.0.1",
-                "@papit/information": "0.0.4",
+                "@papit/information": "0.0.3",
                 "@papit/terminal": "0.0.1",
                 "chokidar": "^5.0.0",
                 "esbuild": "0.27.2"
@@ -1507,7 +1507,7 @@
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
                 "@papit/arguments": "0.0.1",
-                "@papit/information": "0.0.4",
+                "@papit/information": "0.0.3",
                 "@papit/terminal": "0.0.1"
             },
             "bin": {
@@ -1708,7 +1708,7 @@
             "version": "0.0.1",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
-                "@papit/placement": "^0.0.1",
+                "@papit/placement": "0.0.1",
                 "@papit/web-component": "0.0.1"
             },
             "devDependencies": {
@@ -1730,8 +1730,8 @@
             "dependencies": {
                 "@papit/data-structure": "0.0.1",
                 "@papit/icon": "0.1.0",
-                "@papit/lexer": "^0.0.1",
-                "@papit/splitter": "^0.0.1",
+                "@papit/lexer": "0.0.1",
+                "@papit/splitter": "0.0.1",
                 "@papit/switch": "0.1.0",
                 "@papit/tooltip": "0.0.1",
                 "@papit/web-component": "0.0.1"
@@ -1776,7 +1776,7 @@
             "devDependencies": {
                 "@papit/arguments": "0.0.1",
                 "@papit/codeblock": "0.1.0",
-                "@papit/information": "0.0.4",
+                "@papit/information": "0.0.3",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
                 "playwright": "1.58.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
         "clean": "node bin/clean.mjs",
         "test": "node bin/test.mjs",
         "create": "npm create @papit -- --package --html-prefix=pap",
-        "start": "npx @papit/server --info"
+        "start": "npx @papit/server --info",
+        "version-reset": "npx @papit/version --reset",
+        "version-sync": "npx @papit/version --sync"
     },
     "keywords": [
         "typescript"

--- a/packages/runtime/cli/build/package.json
+++ b/packages/runtime/cli/build/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@papit/arguments": "0.0.1",
     "@papit/data-structure": "0.0.1",
-    "@papit/information": "0.0.4",
+    "@papit/information": "0.0.3",
     "@papit/terminal": "0.0.1",
     "@papit/bundle-ts": "0.0.1",
     "@papit/bundle-js": "0.0.2"

--- a/packages/runtime/cli/create/package.json
+++ b/packages/runtime/cli/create/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@papit/create",
   "description": "",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "scripts": {
     "build": "npx @papit/build -- --error --ancestors",
     "watch": "tsc -w",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@papit/arguments": "0.0.1",
-    "@papit/information": "0.0.4",
+    "@papit/information": "0.0.3",
     "@papit/terminal": "0.0.1"
   },
   "devDependencies": {

--- a/packages/runtime/cli/information/package.json
+++ b/packages/runtime/cli/information/package.json
@@ -7,7 +7,7 @@
     "typescript",
     "information"
   ],
-  "version": "0.0.4",
+  "version": "0.0.3",
   "scripts": {
     "prebuild": "node bin/prebuild.mjs",
     "build": "npx @papit/build -- --error --ancestors",

--- a/packages/runtime/cli/information/src/node.ts
+++ b/packages/runtime/cli/information/src/node.ts
@@ -22,6 +22,10 @@ export class PackageNode<T extends LocalPackage | RootPackage = LocalPackage> {
     get type() { return this._type }
     get location() { return path.normalize(this._location) }
 
+    savePackageJSON() {
+        fs.writeFileSync(path.join(this.location, "package.json"), JSON.stringify(this.packageJSON, null, 4), { encoding: "utf-8" });
+    }
+
     get sourceFolder() { return sourceFolder(this.location, this.tsconfig) }
     get outFolder() { return outFolder(this.location, this.tsconfig) }
     get name() { return this._packageJSON.name }

--- a/packages/runtime/cli/server/package.json
+++ b/packages/runtime/cli/server/package.json
@@ -60,7 +60,7 @@
     "@papit/bundle-js": "0.0.2",
     "@papit/deep-merge": "0.0.1",
     "@papit/html": "0.0.1",
-    "@papit/information": "0.0.4",
+    "@papit/information": "0.0.3",
     "@papit/terminal": "0.0.1",
     "chokidar": "^5.0.0",
     "esbuild": "0.27.2"

--- a/packages/runtime/cli/version/package.json
+++ b/packages/runtime/cli/version/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@papit/arguments": "0.0.1",
-    "@papit/information": "0.0.4",
+    "@papit/information": "0.0.3",
     "@papit/terminal": "0.0.1"
   },
   "devDependencies": {

--- a/packages/runtime/cli/version/src/component.ts
+++ b/packages/runtime/cli/version/src/component.ts
@@ -4,8 +4,24 @@ import { post } from "./components/post";
 import { Terminal } from "@papit/terminal";
 import { Arguments } from "@papit/arguments";
 import { Information } from "@papit/information";
+import { reset } from "components/reset";
+import { remote } from "components/remote";
 
 (async function () {
+
+    if (Arguments.has("reset"))
+    {
+        // we reset to remoteVersion and 0.0.1 if none existing 
+        return reset();
+    }
+
+    // would like to call it "remote" but I fear it might collide 
+    if (Arguments.has("sync"))
+    {
+        // we sync the remoteVersion to whats on the remote 
+        return remote();
+    }
+
     if (!Information.package.packageJSON)
     {
         Terminal.error("package.json missing");

--- a/packages/runtime/cli/version/src/components/post.ts
+++ b/packages/runtime/cli/version/src/components/post.ts
@@ -72,7 +72,17 @@ function runner(node: PackageNode, updateDependencies: Map<string, string>) {
         }
 
         // we do a patch if we need 
-        if (changed || node.packageJSON.version !== node.packageJSON.remoteVersion)
+        // if (changed || node.packageJSON.version === node.packageJSON.remoteVersion)
+        // {
+        //     const match = node.packageJSON.version.match(/^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<semver>.*)$/);
+        //     if (match?.groups)
+        //     {
+        //         const { major, minor, patch, semver } = match.groups;
+        //         node.packageJSON.version = `${major}.${minor}.${Number(patch) + 1}${semver}`;
+        //     }
+        // }
+
+        if (changed && node.packageJSON.version === node.packageJSON.remoteVersion)
         {
             const match = node.packageJSON.version.match(/^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<semver>.*)$/);
             if (match?.groups)

--- a/packages/runtime/cli/version/src/components/pre.ts
+++ b/packages/runtime/cli/version/src/components/pre.ts
@@ -1,8 +1,16 @@
 import path from "node:path";
 import fs from "node:fs";
 import { Information } from "@papit/information";
+import { Arguments } from "@papit/arguments";
 
 export async function pre() {
+
+    const remote = await Information.package.remote() ?? Information.package.packageJSON.remoteVersion;
+    if (remote && remote !== Information.package.packageJSON.version)
+    {
+        if (!Arguments.has("force")) throw new Error(`${Information.package.name}@${Information.package.packageJSON.version} is already ahead of remote (${remote}), use --force to override`);
+    }
+
     const PKG_LOCK = path.join(Information.root.location, "package-lock.json"); // trick to not cause npm to spat out npm installs 
     if (!fs.existsSync(PKG_LOCK)) return;
 

--- a/packages/runtime/cli/version/src/components/remote.ts
+++ b/packages/runtime/cli/version/src/components/remote.ts
@@ -1,0 +1,18 @@
+import { Information } from "@papit/information";
+
+export async function remote() {
+    const batches = Information.getBatches();
+    for (const batch of batches)
+    {
+        for (const node of batch)
+        {
+            const remote = await node.remote() ?? "";
+
+            if (remote !== node.packageJSON.remoteVersion)
+            {
+                node.packageJSON.remoteVersion = remote;
+                node.savePackageJSON();
+            }
+        }
+    }
+}

--- a/packages/runtime/cli/version/src/components/reset.ts
+++ b/packages/runtime/cli/version/src/components/reset.ts
@@ -1,0 +1,61 @@
+import { Information } from "@papit/information";
+import { Terminal } from "@papit/terminal";
+
+export async function reset() {
+    const batches = Information.getPriorityBatches();
+    const updateDependencies = new Map<string, string>();
+
+    for (const batch of batches)
+    {
+        for (const node of batch)
+        {
+            let changed = false;
+            const remote = await node.remote() ?? node.packageJSON.remoteVersion;
+            if (!remote)
+            {
+                if (node.packageJSON.version !== "0.0.1")
+                {
+                    node.packageJSON.version = "0.0.1";
+                    changed = true;
+                }
+            }
+            else if (remote !== node.packageJSON.version)
+            {
+                node.packageJSON.version = remote;
+                node.packageJSON.remoteVersion = remote;
+                changed = true;
+            }
+
+            for (const [name, version] of updateDependencies)
+            {
+                if (node.packageJSON.dependencies?.[name] && node.packageJSON.dependencies[name] !== version)
+                {
+                    node.packageJSON.dependencies[name] = version;
+                    changed = true;
+                }
+                if (node.packageJSON.devDependencies?.[name] && node.packageJSON.devDependencies[name] !== version)
+                {
+                    node.packageJSON.devDependencies[name] = version;
+                    changed = true;
+                }
+                if (node.packageJSON.peerDependencies?.[name] && node.packageJSON.peerDependencies[name] !== version)
+                {
+                    node.packageJSON.peerDependencies[name] = version;
+                    changed = true;
+                }
+            }
+
+            updateDependencies.set(node.packageJSON.name, node.packageJSON.version);
+
+            if (changed)
+            {
+                Terminal.write(Terminal.yellow("●"), Terminal.dim(node.name), Terminal.yellow("reset"));
+                node.savePackageJSON();
+            }
+            else 
+            {
+                Terminal.write(Terminal.blue("●"), Terminal.dim(node.name), Terminal.blue("skipped"));
+            }
+        }
+    }
+}

--- a/packages/web/design-system/atoms/tooltip/package.json
+++ b/packages/web/design-system/atoms/tooltip/package.json
@@ -54,7 +54,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@papit/placement": "^0.0.1",
+    "@papit/placement": "0.0.1",
     "@papit/web-component": "0.0.1"
   },
   "devDependencies": {

--- a/packages/web/design-system/molecules/codeblock/package.json
+++ b/packages/web/design-system/molecules/codeblock/package.json
@@ -56,8 +56,8 @@
   "dependencies": {
     "@papit/data-structure": "0.0.1",
     "@papit/icon": "0.1.0",
-    "@papit/lexer": "^0.0.1",
-    "@papit/splitter": "^0.0.1",
+    "@papit/lexer": "0.0.1",
+    "@papit/splitter": "0.0.1",
     "@papit/switch": "0.1.0",
     "@papit/tooltip": "0.0.1",
     "@papit/web-component": "0.0.1"

--- a/packages/web/engines/web-component/package.json
+++ b/packages/web/engines/web-component/package.json
@@ -57,7 +57,7 @@
     "@playwright/test": "1.58.0",
     "playwright": "1.58.0",
     "@papit/arguments": "0.0.1",
-    "@papit/information": "0.0.4",
+    "@papit/information": "0.0.3",
     "@papit/translator": "0.1.0",
     "@papit/codeblock": "0.1.0",
     "typescript": "5.9.3"


### PR DESCRIPTION
issue: #69

changelog:

- fix: pipeline with remote flag for builds

- add: introduce savePackageJson on node

- add: sync and reset modes for version

- reset: package versions

- fix: version bump controll

- version: bump @information