### PR TITLE
feature/71-publish-and-build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Build
         env:
           CI: true
-        run: npm run build -- --ci --run-build --remote
+        run: npm run build -- --ci --remote
 
       - name: Publish to npmjs.com
-        run: npm run publish -- --ci ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+        run: npm run publish -- ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
         env:
           CI: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build
         env: 
           CI: true
-        run: npm run build -- --ci --run-build --remote
+        run: npm run build -- --ci --remote
 
       # Long-lived Playwright cache (read-only in PRs)
       - name: Restore Playwright cache

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         env:
           CI: true
-        run: npm run build -- --ci --run-build
+        run: npm run build -- --ci
 
       - name: Restore Playwright cache
         uses: actions/cache@v4

--- a/bin/prebuild.mjs
+++ b/bin/prebuild.mjs
@@ -22,14 +22,14 @@ const prebuilds = [
 
     for (const { name, location } of prebuilds)
     {
-        console.log('running prebuild', name);
+        if (!process.env.CI) console.log('running prebuild', name);
         await spawnCommand("node bin/prebuild.mjs", path.join(root, location));
     }
 
-    console.log('running build @papit/build');
+    if (!process.env.CI) console.log('running build @papit/build');
     await spawnCommand("npm run build -- --force", path.join(root, "packages/runtime/cli/build"));
 
-    console.log('running build @papit/server');
+    if (!process.env.CI) console.log('running build @papit/server');
     await spawnCommand("npm run build", path.join(root, "packages/runtime/cli/server")); // making sure we can start things like test server for CI 
 
     await spawnCommand(process.env.CI ? "npm ci" : "npm install", root);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,7 +1375,7 @@
                 "@papit/terminal": "0.0.1"
             },
             "bin": {
-                "papit-build": "lib/bundle.js"
+                "papit-build": "lib/bin.js"
             },
             "devDependencies": {
                 "@types/node": "22.10.2"

--- a/packages/algorithms/data-structure/package.json
+++ b/packages/algorithms/data-structure/package.json
@@ -1,79 +1,80 @@
 {
-  "name": "@papit/data-structure",
-  "description": "A collection of data models not existing in JavaScript",
-  "keywords": [
-    "papit",
-    "node",
-    "typescript",
-    "data-structure"
-  ],
-  "version": "0.0.1",
-  "scripts": {
-    "prebuild": "node bin/prebuild.mjs",
-    "build": "npx @papit/build -- --error --ancestors",
-    "watch": "tsc -w",
-    "start": "npm run build -- --dev && node ./lib/bundle.js",
-    "test": "node --test tests/**/*.test.js",
-    "test:only": "node --test --test-only tests/**/*.test.js",
-    "preversion": "papit-version",
-    "postversion": "papit-version",
-    "component": "npm create @papit -- --component"
-  },
-  "main": "./lib/bundle.js",
-  "types": "./lib/bundle.d.ts",
-  "type": "module",
-  "files": [
-    "asset/",
-    "lib/"
-  ],
-  "exports": {
-    ".": {
-      "import": "./lib/bundle.js",
-      "types": "./lib/bundle.d.ts"
-    }
-  },
-  "author": "henry",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "license": "LicenseRef-Papit-1.0",
-  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/algorithms/data-structure",
-  "bugs": {
-    "url": "https://github.com/onkelhoy/papit/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/onkelhoy/papit.git",
-    "directory": "packages/algorithms/data-structure"
-  },
-  "sideEffects": true,
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "@types/node": "22.10.2",
-    "typescript": "5.9.3",
-    "@papit/bundle-ts": "0.0.1",
-    "@papit/bundle-js": "0.0.2"
-  },
-  "browserslist": [
-    "defaults",
-    "not IE 11",
-    "not dead"
-  ],
-  "papit": {
-    "publish": true,
-    "type": "node",
-    "main": "data-structure",
-    "priority": 1,
-    "components": {
-      "data-structure": {
-        "className": "DataModels",
-        "htmlprefix": "pap"
-      }
-    }
-  }
+    "name": "@papit/data-structure",
+    "description": "A collection of data models not existing in JavaScript",
+    "keywords": [
+        "papit",
+        "node",
+        "typescript",
+        "data-structure"
+    ],
+    "version": "0.0.1",
+    "scripts": {
+        "prebuild": "node bin/prebuild.mjs",
+        "build": "npx @papit/build -- --error --ancestors",
+        "watch": "tsc -w",
+        "start": "npm run build -- --dev && node ./lib/bundle.js",
+        "test": "node --test tests/**/*.test.js",
+        "test:only": "node --test --test-only tests/**/*.test.js",
+        "preversion": "papit-version",
+        "postversion": "papit-version",
+        "component": "npm create @papit -- --component"
+    },
+    "main": "./lib/bundle.js",
+    "types": "./lib/bundle.d.ts",
+    "type": "module",
+    "files": [
+        "asset/",
+        "lib/"
+    ],
+    "exports": {
+        ".": {
+            "import": "./lib/bundle.js",
+            "types": "./lib/bundle.d.ts"
+        }
+    },
+    "author": "henry",
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
+    "license": "LicenseRef-Papit-1.0",
+    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/algorithms/data-structure",
+    "bugs": {
+        "url": "https://github.com/onkelhoy/papit/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/onkelhoy/papit.git",
+        "directory": "packages/algorithms/data-structure"
+    },
+    "sideEffects": true,
+    "engines": {
+        "node": ">=18"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "@types/node": "22.10.2",
+        "typescript": "5.9.3",
+        "@papit/bundle-ts": "0.0.1",
+        "@papit/bundle-js": "0.0.2"
+    },
+    "browserslist": [
+        "defaults",
+        "not IE 11",
+        "not dead"
+    ],
+    "papit": {
+        "publish": true,
+        "type": "node",
+        "main": "data-structure",
+        "priority": 1,
+        "components": {
+            "data-structure": {
+                "className": "DataModels",
+                "htmlprefix": "pap"
+            }
+        }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/algorithms/deep-merge/package.json
+++ b/packages/algorithms/deep-merge/package.json
@@ -1,79 +1,80 @@
 {
-  "name": "@papit/deep-merge",
-  "description": "a simple package dealing witg merging objects, it would take the last object ",
-  "keywords": [
-    "papit",
-    "node",
-    "typescript",
-    "deep-merge"
-  ],
-  "version": "0.0.1",
-  "scripts": {
-    "prebuild": "node bin/prebuild.mjs",
-    "build": "npx @papit/build --error",
-    "watch": "tsc -w",
-    "start": "npm run build -- --dev && node ./lib/bundle.js",
-    "test": "node --test tests/**/*.test.js",
-    "test:only": "node --test --test-only tests/**/*.test.js",
-    "preversion": "papit-version",
-    "postversion": "papit-version",
-    "component": "npm create @papit -- --component"
-  },
-  "main": "./lib/bundle.js",
-  "types": "./lib/bundle.d.ts",
-  "type": "module",
-  "files": [
-    "asset/",
-    "lib/"
-  ],
-  "exports": {
-    ".": {
-      "import": "./lib/bundle.js",
-      "types": "./lib/bundle.d.ts"
-    }
-  },
-  "author": "henry",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "license": "LicenseRef-Papit-1.0",
-  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/algorithms/deep-merge",
-  "bugs": {
-    "url": "https://github.com/onkelhoy/papit/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/onkelhoy/papit.git",
-    "directory": "packages/algorithms/deep-merge"
-  },
-  "sideEffects": true,
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "@types/node": "22.10.2",
-    "typescript": "5.9.3",
-    "@papit/bundle-ts": "0.0.1",
-    "@papit/bundle-js": "0.0.2"
-  },
-  "browserslist": [
-    "defaults",
-    "not IE 11",
-    "not dead"
-  ],
-  "papit": {
-    "publish": true,
-    "type": "node",
-    "main": "deep-merge",
-    "priority": 1,
-    "components": {
-      "deep-merge": {
-        "className": "DeepMerge",
-        "htmlprefix": "pap"
-      }
-    }
-  }
+    "name": "@papit/deep-merge",
+    "description": "a simple package dealing witg merging objects, it would take the last object ",
+    "keywords": [
+        "papit",
+        "node",
+        "typescript",
+        "deep-merge"
+    ],
+    "version": "0.0.1",
+    "scripts": {
+        "prebuild": "node bin/prebuild.mjs",
+        "build": "npx @papit/build --error",
+        "watch": "tsc -w",
+        "start": "npm run build -- --dev && node ./lib/bundle.js",
+        "test": "node --test tests/**/*.test.js",
+        "test:only": "node --test --test-only tests/**/*.test.js",
+        "preversion": "papit-version",
+        "postversion": "papit-version",
+        "component": "npm create @papit -- --component"
+    },
+    "main": "./lib/bundle.js",
+    "types": "./lib/bundle.d.ts",
+    "type": "module",
+    "files": [
+        "asset/",
+        "lib/"
+    ],
+    "exports": {
+        ".": {
+            "import": "./lib/bundle.js",
+            "types": "./lib/bundle.d.ts"
+        }
+    },
+    "author": "henry",
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
+    "license": "LicenseRef-Papit-1.0",
+    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/algorithms/deep-merge",
+    "bugs": {
+        "url": "https://github.com/onkelhoy/papit/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/onkelhoy/papit.git",
+        "directory": "packages/algorithms/deep-merge"
+    },
+    "sideEffects": true,
+    "engines": {
+        "node": ">=18"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "@types/node": "22.10.2",
+        "typescript": "5.9.3",
+        "@papit/bundle-ts": "0.0.1",
+        "@papit/bundle-js": "0.0.2"
+    },
+    "browserslist": [
+        "defaults",
+        "not IE 11",
+        "not dead"
+    ],
+    "papit": {
+        "publish": true,
+        "type": "node",
+        "main": "deep-merge",
+        "priority": 1,
+        "components": {
+            "deep-merge": {
+                "className": "DeepMerge",
+                "htmlprefix": "pap"
+            }
+        }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/algorithms/math/algebra/matrix/package.json
+++ b/packages/algorithms/math/algebra/matrix/package.json
@@ -72,5 +72,6 @@
                 "htmlprefix": "pap"
             }
         }
-    }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/algorithms/math/algebra/vector/package.json
+++ b/packages/algorithms/math/algebra/vector/package.json
@@ -70,5 +70,6 @@
                 "htmlprefix": "pap"
             }
         }
-    }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/network/meta-json/package.json
+++ b/packages/network/meta-json/package.json
@@ -70,5 +70,6 @@
                 "htmlprefix": "pap"
             }
         }
-    }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/runtime/cli/arguments/package.json
+++ b/packages/runtime/cli/arguments/package.json
@@ -1,79 +1,80 @@
 {
-  "name": "@papit/arguments",
-  "description": "a simple package to deal with arguments, default behaviour will look on process.argv but it will also expose a function to extract based on string ",
-  "keywords": [
-    "papit",
-    "node",
-    "typescript",
-    "arguments"
-  ],
-  "version": "0.0.1",
-  "scripts": {
-    "prebuild": "node bin/prebuild.mjs",
-    "build": "npx @papit/build --error",
-    "watch": "tsc -w",
-    "start": "npm run build -- --dev && node ./lib/bundle.js",
-    "test": "node --test tests/**/*.test.js",
-    "test:only": "node --test --test-only tests/**/*.test.js",
-    "preversion": "papit-version",
-    "postversion": "papit-version",
-    "component": "npm create @papit -- --component"
-  },
-  "main": "./lib/bundle.js",
-  "types": "./lib/bundle.d.ts",
-  "type": "module",
-  "files": [
-    "asset/",
-    "lib/"
-  ],
-  "exports": {
-    ".": {
-      "import": "./lib/bundle.js",
-      "types": "./lib/bundle.d.ts"
-    }
-  },
-  "author": "henry",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "license": "LicenseRef-Papit-1.0",
-  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/arguments",
-  "bugs": {
-    "url": "https://github.com/onkelhoy/papit/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/onkelhoy/papit.git",
-    "directory": "packages/runtime/cli/arguments"
-  },
-  "sideEffects": true,
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "@types/node": "22.10.2",
-    "typescript": "5.9.3",
-    "@papit/bundle-js": "0.0.2",
-    "@papit/bundle-ts": "0.0.1"
-  },
-  "browserslist": [
-    "defaults",
-    "not IE 11",
-    "not dead"
-  ],
-  "papit": {
-    "publish": true,
-    "type": "node",
-    "main": "arguments",
-    "priority": 2,
-    "components": {
-      "arguments": {
-        "className": "Arguments",
-        "htmlprefix": "pap"
-      }
-    }
-  }
+    "name": "@papit/arguments",
+    "description": "a simple package to deal with arguments, default behaviour will look on process.argv but it will also expose a function to extract based on string ",
+    "keywords": [
+        "papit",
+        "node",
+        "typescript",
+        "arguments"
+    ],
+    "version": "0.0.1",
+    "scripts": {
+        "prebuild": "node bin/prebuild.mjs",
+        "build": "npx @papit/build --error",
+        "watch": "tsc -w",
+        "start": "npm run build -- --dev && node ./lib/bundle.js",
+        "test": "node --test tests/**/*.test.js",
+        "test:only": "node --test --test-only tests/**/*.test.js",
+        "preversion": "papit-version",
+        "postversion": "papit-version",
+        "component": "npm create @papit -- --component"
+    },
+    "main": "./lib/bundle.js",
+    "types": "./lib/bundle.d.ts",
+    "type": "module",
+    "files": [
+        "asset/",
+        "lib/"
+    ],
+    "exports": {
+        ".": {
+            "import": "./lib/bundle.js",
+            "types": "./lib/bundle.d.ts"
+        }
+    },
+    "author": "henry",
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
+    "license": "LicenseRef-Papit-1.0",
+    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/arguments",
+    "bugs": {
+        "url": "https://github.com/onkelhoy/papit/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/onkelhoy/papit.git",
+        "directory": "packages/runtime/cli/arguments"
+    },
+    "sideEffects": true,
+    "engines": {
+        "node": ">=18"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "@types/node": "22.10.2",
+        "typescript": "5.9.3",
+        "@papit/bundle-js": "0.0.2",
+        "@papit/bundle-ts": "0.0.1"
+    },
+    "browserslist": [
+        "defaults",
+        "not IE 11",
+        "not dead"
+    ],
+    "papit": {
+        "publish": true,
+        "type": "node",
+        "main": "arguments",
+        "priority": 2,
+        "components": {
+            "arguments": {
+                "className": "Arguments",
+                "htmlprefix": "pap"
+            }
+        }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/runtime/cli/build/package.json
+++ b/packages/runtime/cli/build/package.json
@@ -10,9 +10,9 @@
   "version": "0.0.2",
   "scripts": {
     "prebuild": "node bin/prebuild.mjs",
-    "build": "node lib/bundle.js --error --run-build",
+    "build": "node lib/bin.js --error",
     "watch": "tsc -w",
-    "start": "npm run build -- --dev && node ./lib/bundle.js",
+    "start": "npm run build -- --dev && node ./lib/bin.js",
     "test": "node --test tests/**/*.test.js",
     "test:only": "node --test --test-only tests/**/*.test.js",
     "preversion": "papit-version",
@@ -33,7 +33,7 @@
     }
   },
   "bin": {
-    "papit-build": "./lib/bundle.js"
+    "papit-build": "./lib/bin.js"
   },
   "author": "henry",
   "private": false,

--- a/packages/runtime/cli/build/src/bin.ts
+++ b/packages/runtime/cli/build/src/bin.ts
@@ -1,0 +1,6 @@
+import { build } from ".";
+import { Args } from "@papit/arguments";
+
+(async function () {
+    await build(new Args([...process.argv, "--can-print"]));
+}())

--- a/packages/runtime/cli/build/src/index.ts
+++ b/packages/runtime/cli/build/src/index.ts
@@ -11,28 +11,12 @@ import { tsBundle } from "@papit/bundle-ts";
 
 import { npmInstall } from "helper";
 
-function canRun() {
-    return Arguments.has("run-build") || Arguments.isCLI;
-}
-
-function canPrint() {
-    if (!canRun()) return false;
-    // Windows-safe binary name check
-    const execPath = process.env._ ?? process.env.npm_lifecycle_script ?? "";
-    return execPath.endsWith("papit-build") || Arguments.has("run-build");
-}
-
-(async function () {
-    if (!canRun()) return;
-    await build();
-}())
-
 export async function build(
     args = new Args(process.argv),
     node?: PackageNode,
     onPackageBuild?: (node: PackageNode, info: "failed" | "skipped" | "success") => void,
 ) {
-    const canprint = canPrint();
+    const canprint = args.has("can-print");
     const failed = new Set<string>();
 
     let logLevel: LogLevel = "silent";

--- a/packages/runtime/cli/bundle-js/package.json
+++ b/packages/runtime/cli/bundle-js/package.json
@@ -1,79 +1,80 @@
 {
-  "name": "@papit/bundle-js",
-  "description": "a minimal build to be able to help build package and pre-build scripts",
-  "keywords": [
-    "papit",
-    "node",
-    "typescript",
-    "bundle-js"
-  ],
-  "version": "0.0.2",
-  "scripts": {
-    "prebuild": "node bin/prebuild.mjs",
-    "build": "npx @papit/build --error",
-    "watch": "tsc -w",
-    "start": "npm run build -- --dev && node ./lib/bundle.js",
-    "test": "node --test tests/**/*.test.js",
-    "test:only": "node --test --test-only tests/**/*.test.js",
-    "preversion": "papit-version",
-    "postversion": "papit-version",
-    "component": "npm create @papit -- --component"
-  },
-  "main": "./lib/bundle.js",
-  "types": "./lib/bundle.d.ts",
-  "type": "module",
-  "files": [
-    "asset/",
-    "lib/"
-  ],
-  "exports": {
-    ".": {
-      "import": "./lib/bundle.js",
-      "types": "./lib/bundle.d.ts"
-    }
-  },
-  "author": "henry",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "license": "LicenseRef-Papit-1.0",
-  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/bundle-js",
-  "bugs": {
-    "url": "https://github.com/onkelhoy/papit/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/onkelhoy/papit.git",
-    "directory": "packages/runtime/cli/bundle-js"
-  },
-  "sideEffects": true,
-  "engines": {
-    "node": ">=18"
-  },
-  "peerDependencies": {
-    "esbuild": "0.27.2"
-  },
-  "devDependencies": {
-    "@types/node": "22.10.2",
-    "typescript": "5.9.3"
-  },
-  "browserslist": [
-    "defaults",
-    "not IE 11",
-    "not dead"
-  ],
-  "papit": {
-    "publish": true,
-    "priority": 1,
-    "type": "node",
-    "main": "bundle-js",
-    "components": {
-      "bundle-js": {
-        "className": "BundleJs",
-        "htmlprefix": "pap"
-      }
-    }
-  }
+    "name": "@papit/bundle-js",
+    "description": "a minimal build to be able to help build package and pre-build scripts",
+    "keywords": [
+        "papit",
+        "node",
+        "typescript",
+        "bundle-js"
+    ],
+    "version": "0.0.2",
+    "scripts": {
+        "prebuild": "node bin/prebuild.mjs",
+        "build": "npx @papit/build --error",
+        "watch": "tsc -w",
+        "start": "npm run build -- --dev && node ./lib/bundle.js",
+        "test": "node --test tests/**/*.test.js",
+        "test:only": "node --test --test-only tests/**/*.test.js",
+        "preversion": "papit-version",
+        "postversion": "papit-version",
+        "component": "npm create @papit -- --component"
+    },
+    "main": "./lib/bundle.js",
+    "types": "./lib/bundle.d.ts",
+    "type": "module",
+    "files": [
+        "asset/",
+        "lib/"
+    ],
+    "exports": {
+        ".": {
+            "import": "./lib/bundle.js",
+            "types": "./lib/bundle.d.ts"
+        }
+    },
+    "author": "henry",
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
+    "license": "LicenseRef-Papit-1.0",
+    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/bundle-js",
+    "bugs": {
+        "url": "https://github.com/onkelhoy/papit/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/onkelhoy/papit.git",
+        "directory": "packages/runtime/cli/bundle-js"
+    },
+    "sideEffects": true,
+    "engines": {
+        "node": ">=18"
+    },
+    "peerDependencies": {
+        "esbuild": "0.27.2"
+    },
+    "devDependencies": {
+        "@types/node": "22.10.2",
+        "typescript": "5.9.3"
+    },
+    "browserslist": [
+        "defaults",
+        "not IE 11",
+        "not dead"
+    ],
+    "papit": {
+        "publish": true,
+        "priority": 1,
+        "type": "node",
+        "main": "bundle-js",
+        "components": {
+            "bundle-js": {
+                "className": "BundleJs",
+                "htmlprefix": "pap"
+            }
+        }
+    },
+    "remoteVersion": "0.0.2"
 }

--- a/packages/runtime/cli/bundle-ts/package.json
+++ b/packages/runtime/cli/bundle-ts/package.json
@@ -1,78 +1,79 @@
 {
-  "name": "@papit/bundle-ts",
-  "description": "typescript bundler replacing the aweful microsoft-api-extractor that comes with 80 deps",
-  "keywords": [
-    "papit",
-    "node",
-    "typescript",
-    "bundle-ts"
-  ],
-  "version": "0.0.1",
-  "scripts": {
-    "prebuild": "node bin/prebuild.mjs",
-    "build": "npx @papit/build --error",
-    "watch": "tsc -w",
-    "start": "npm run prebuild && node ./lib/bundle.js",
-    "test": "node --test tests/**/*.test.js",
-    "test:only": "node --test --test-only tests/**/*.test.js",
-    "preversion": "papit-version",
-    "postversion": "papit-version",
-    "component": "npm create @papit -- --component"
-  },
-  "main": "./lib/bundle.js",
-  "types": "./lib/bundle.d.ts",
-  "type": "module",
-  "files": [
-    "asset/",
-    "lib/"
-  ],
-  "bin": {
-    "papit-bundle-ts": "./lib/bundle.js"
-  },
-  "exports": {
-    ".": {
-      "import": "./lib/bundle.js",
-      "types": "./lib/bundle.d.ts"
-    }
-  },
-  "author": "henry",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "license": "LicenseRef-Papit-1.0",
-  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/bundle-ts",
-  "bugs": {
-    "url": "https://github.com/onkelhoy/papit/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/onkelhoy/papit.git",
-    "directory": "packages/runtime/cli/bundle-ts"
-  },
-  "sideEffects": true,
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {
-    "@microsoft/api-extractor": "7.58.7",
-    "@papit/bundle-js": "0.0.2"
-  },
-  "peerDependencies": {
-    "typescript": "5.9.3"
-  },
-  "devDependencies": {
-    "@types/node": "22.10.2"
-  },
-  "browserslist": [
-    "defaults",
-    "not IE 11",
-    "not dead"
-  ],
-  "papit": {
-    "priority": 2,
-    "publish": true,
-    "type": "node"
-  }
+    "name": "@papit/bundle-ts",
+    "description": "typescript bundler replacing the aweful microsoft-api-extractor that comes with 80 deps",
+    "keywords": [
+        "papit",
+        "node",
+        "typescript",
+        "bundle-ts"
+    ],
+    "version": "0.0.1",
+    "scripts": {
+        "prebuild": "node bin/prebuild.mjs",
+        "build": "npx @papit/build --error",
+        "watch": "tsc -w",
+        "start": "npm run prebuild && node ./lib/bundle.js",
+        "test": "node --test tests/**/*.test.js",
+        "test:only": "node --test --test-only tests/**/*.test.js",
+        "preversion": "papit-version",
+        "postversion": "papit-version",
+        "component": "npm create @papit -- --component"
+    },
+    "main": "./lib/bundle.js",
+    "types": "./lib/bundle.d.ts",
+    "type": "module",
+    "files": [
+        "asset/",
+        "lib/"
+    ],
+    "bin": {
+        "papit-bundle-ts": "./lib/bundle.js"
+    },
+    "exports": {
+        ".": {
+            "import": "./lib/bundle.js",
+            "types": "./lib/bundle.d.ts"
+        }
+    },
+    "author": "henry",
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
+    "license": "LicenseRef-Papit-1.0",
+    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/bundle-ts",
+    "bugs": {
+        "url": "https://github.com/onkelhoy/papit/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/onkelhoy/papit.git",
+        "directory": "packages/runtime/cli/bundle-ts"
+    },
+    "sideEffects": true,
+    "engines": {
+        "node": ">=18"
+    },
+    "dependencies": {
+        "@microsoft/api-extractor": "7.58.7",
+        "@papit/bundle-js": "0.0.2"
+    },
+    "peerDependencies": {
+        "typescript": "5.9.3"
+    },
+    "devDependencies": {
+        "@types/node": "22.10.2"
+    },
+    "browserslist": [
+        "defaults",
+        "not IE 11",
+        "not dead"
+    ],
+    "papit": {
+        "priority": 2,
+        "publish": true,
+        "type": "node"
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/runtime/cli/create/asset/project-template/.github/workflows/publish.yml
+++ b/packages/runtime/cli/create/asset/project-template/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         env:
           CI: true
-        run: npm run build -- --ci --run-build
+        run: npm run build -- --ci
 
       - name: Publish to npmjs.com
         run: npm run publish -- --ci ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}

--- a/packages/runtime/cli/create/asset/project-template/.github/workflows/pull-request.yml
+++ b/packages/runtime/cli/create/asset/project-template/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build
         env: 
           CI: true
-        run: npm run build -- --ci --run-build
+        run: npm run build -- --ci
 
       # Long-lived Playwright cache (read-only in PRs)
       - name: Restore Playwright cache

--- a/packages/runtime/cli/create/asset/project-template/.github/workflows/update-snapshots.yml
+++ b/packages/runtime/cli/create/asset/project-template/.github/workflows/update-snapshots.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         env:
           CI: true
-        run: npm run build -- --ci --run-build
+        run: npm run build -- --ci
 
       - name: Restore Playwright cache
         uses: actions/cache@v4

--- a/packages/runtime/cli/create/package.json
+++ b/packages/runtime/cli/create/package.json
@@ -1,73 +1,73 @@
 {
-  "name": "@papit/create",
-  "description": "",
-  "version": "0.0.3",
-  "scripts": {
-    "build": "npx @papit/build -- --error --ancestors",
-    "watch": "tsc -w",
-    "start": "npm run build -- --dev && node ./lib/bundle.js",
-    "test": "node --test tests/**/*.test.js",
-    "preversion": "papit-version",
-    "postversion": "papit-version",
-    "component": "npm create @papit -- --component"
-  },
-  "main": "./lib/bundle.js",
-  "types": "./lib/bundle.d.ts",
-  "type": "module",
-  "files": [
-    "lib/",
-    "asset/"
-  ],
-  "exports": {
-    ".": {
-      "import": "./lib/bundle.js",
-      "types": "./lib/bundle.d.ts"
-    }
-  },
-  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/create",
-  "bugs": {
-    "url": "https://github.com/onkelhoy/papit/issues"
-  },
-  "author": "Henry",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "license": "Papit-1.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/onkelhoy/papit.git",
-    "directory": "packages/runtime/cli/create"
-  },
-  "sideEffects": true,
-  "engines": {
-    "node": ">=18"
-  },
-  "bin": {
-    "papit-create": "./lib/bundle.js"
-  },
-  "dependencies": {
-    "@papit/arguments": "0.0.1",
-    "@papit/information": "0.0.3",
-    "@papit/terminal": "0.0.1"
-  },
-  "devDependencies": {
-    "@types/node": "22.10.2",
-    "typescript": "5.9.3"
-  },
-  "keywords": [
-    "node",
-    "typescript"
-  ],
-  "papit": {
-    "publish": true,
-    "type": "node",
-    "main": {
-      "name": "create",
-      "className": "Create"
+    "name": "@papit/create",
+    "description": "",
+    "version": "0.0.3",
+    "scripts": {
+        "build": "npx @papit/build -- --error --ancestors",
+        "watch": "tsc -w",
+        "start": "npm run build -- --dev && node ./lib/bundle.js",
+        "test": "node --test tests/**/*.test.js",
+        "preversion": "papit-version",
+        "postversion": "papit-version",
+        "component": "npm create @papit -- --component"
     },
-    "components": {}
-  },
-  "remoteVersion": "0.0.2"
+    "main": "./lib/bundle.js",
+    "types": "./lib/bundle.d.ts",
+    "type": "module",
+    "files": [
+        "lib/",
+        "asset/"
+    ],
+    "exports": {
+        ".": {
+            "import": "./lib/bundle.js",
+            "types": "./lib/bundle.d.ts"
+        }
+    },
+    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/create",
+    "bugs": {
+        "url": "https://github.com/onkelhoy/papit/issues"
+    },
+    "author": "Henry",
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
+    "license": "Papit-1.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/onkelhoy/papit.git",
+        "directory": "packages/runtime/cli/create"
+    },
+    "sideEffects": true,
+    "engines": {
+        "node": ">=18"
+    },
+    "bin": {
+        "papit-create": "./lib/bundle.js"
+    },
+    "dependencies": {
+        "@papit/arguments": "0.0.1",
+        "@papit/information": "0.0.3",
+        "@papit/terminal": "0.0.1"
+    },
+    "devDependencies": {
+        "@types/node": "22.10.2",
+        "typescript": "5.9.3"
+    },
+    "keywords": [
+        "node",
+        "typescript"
+    ],
+    "papit": {
+        "publish": true,
+        "type": "node",
+        "main": {
+            "name": "create",
+            "className": "Create"
+        },
+        "components": {}
+    },
+    "remoteVersion": "0.0.3"
 }

--- a/packages/runtime/cli/information/src/remote.ts
+++ b/packages/runtime/cli/information/src/remote.ts
@@ -1,3 +1,4 @@
+import { Arguments } from "@papit/arguments";
 import { PackageGraph } from "./graph";
 import { Information } from "./information";
 import type { RemotePackage, RemotePackages } from "./types";
@@ -13,6 +14,8 @@ export class Remote {
 
         try
         {
+            if (!Arguments.has("allow-global")) return;
+
             this.abortsignal = new AbortController();
             const res = await fetch(
                 `https://registry.npmjs.org/-/v1/search?text=${scope}&size=${size}&from=${from}`,

--- a/packages/runtime/cli/terminal/package.json
+++ b/packages/runtime/cli/terminal/package.json
@@ -1,77 +1,78 @@
 {
-  "name": "@papit/terminal",
-  "description": "heart component for cli, dealing with logging to a terminal, with fancy methods like prompt and option ",
-  "keywords": [
-    "papit",
-    "node",
-    "typescript",
-    "terminal"
-  ],
-  "version": "0.0.1",
-  "scripts": {
-    "prebuild": "node bin/prebuild.mjs",
-    "build": "npx @papit/build --error",
-    "watch": "tsc -w",
-    "start": "npm run build -- --dev && node ./lib/bundle.js",
-    "test": "node --test tests/**/*.test.js",
-    "test:only": "node --test --test-only tests/**/*.test.js",
-    "preversion": "papit-version",
-    "postversion": "papit-version",
-    "component": "npm create @papit -- --component"
-  },
-  "main": "./lib/bundle.js",
-  "types": "./lib/bundle.d.ts",
-  "type": "module",
-  "files": [
-    "asset/",
-    "lib/"
-  ],
-  "exports": {
-    ".": {
-      "import": "./lib/bundle.js",
-      "types": "./lib/bundle.d.ts"
-    }
-  },
-  "author": "henry",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "license": "LicenseRef-Papit-1.0",
-  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/terminal",
-  "bugs": {
-    "url": "https://github.com/onkelhoy/papit/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/onkelhoy/papit.git",
-    "directory": "packages/runtime/cli/terminal"
-  },
-  "sideEffects": true,
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "@types/node": "22.10.2",
-    "typescript": "5.9.3"
-  },
-  "browserslist": [
-    "defaults",
-    "not IE 11",
-    "not dead"
-  ],
-  "papit": {
-    "publish": true,
-    "type": "node",
-    "main": "terminal",
-    "priority": 2,
-    "components": {
-      "terminal": {
-        "className": "Terminal",
-        "htmlprefix": "pap"
-      }
-    }
-  }
+    "name": "@papit/terminal",
+    "description": "heart component for cli, dealing with logging to a terminal, with fancy methods like prompt and option ",
+    "keywords": [
+        "papit",
+        "node",
+        "typescript",
+        "terminal"
+    ],
+    "version": "0.0.1",
+    "scripts": {
+        "prebuild": "node bin/prebuild.mjs",
+        "build": "npx @papit/build --error",
+        "watch": "tsc -w",
+        "start": "npm run build -- --dev && node ./lib/bundle.js",
+        "test": "node --test tests/**/*.test.js",
+        "test:only": "node --test --test-only tests/**/*.test.js",
+        "preversion": "papit-version",
+        "postversion": "papit-version",
+        "component": "npm create @papit -- --component"
+    },
+    "main": "./lib/bundle.js",
+    "types": "./lib/bundle.d.ts",
+    "type": "module",
+    "files": [
+        "asset/",
+        "lib/"
+    ],
+    "exports": {
+        ".": {
+            "import": "./lib/bundle.js",
+            "types": "./lib/bundle.d.ts"
+        }
+    },
+    "author": "henry",
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
+    "license": "LicenseRef-Papit-1.0",
+    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/terminal",
+    "bugs": {
+        "url": "https://github.com/onkelhoy/papit/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/onkelhoy/papit.git",
+        "directory": "packages/runtime/cli/terminal"
+    },
+    "sideEffects": true,
+    "engines": {
+        "node": ">=18"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "@types/node": "22.10.2",
+        "typescript": "5.9.3"
+    },
+    "browserslist": [
+        "defaults",
+        "not IE 11",
+        "not dead"
+    ],
+    "papit": {
+        "publish": true,
+        "type": "node",
+        "main": "terminal",
+        "priority": 2,
+        "components": {
+            "terminal": {
+                "className": "Terminal",
+                "htmlprefix": "pap"
+            }
+        }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/runtime/cli/version/src/components/remote.ts
+++ b/packages/runtime/cli/version/src/components/remote.ts
@@ -1,6 +1,9 @@
+import { Arguments } from "@papit/arguments";
 import { Information } from "@papit/information";
+import { Terminal } from "@papit/terminal";
 
 export async function remote() {
+
     const batches = Information.getBatches();
     for (const batch of batches)
     {
@@ -12,6 +15,11 @@ export async function remote() {
             {
                 node.packageJSON.remoteVersion = remote;
                 node.savePackageJSON();
+                Terminal.write(Terminal.yellow("●"), Terminal.dim(node.name), Terminal.yellow("synched"));
+            }
+            else 
+            {
+                Terminal.write(Terminal.blue("●"), Terminal.dim(node.name), Terminal.blue("skipped"));
             }
         }
     }

--- a/packages/runtime/cli/version/src/components/reset.ts
+++ b/packages/runtime/cli/version/src/components/reset.ts
@@ -1,7 +1,9 @@
+import { Arguments } from "@papit/arguments";
 import { Information } from "@papit/information";
 import { Terminal } from "@papit/terminal";
 
 export async function reset() {
+
     const batches = Information.getPriorityBatches();
     const updateDependencies = new Map<string, string>();
 

--- a/packages/runtime/html/package.json
+++ b/packages/runtime/html/package.json
@@ -78,5 +78,6 @@
                 "className": "Element"
             }
         }
-    }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/runtime/lexer/package.json
+++ b/packages/runtime/lexer/package.json
@@ -71,5 +71,6 @@
                 "htmlprefix": "pap"
             }
         }
-    }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/runtime/svg-spritesheet/package.json
+++ b/packages/runtime/svg-spritesheet/package.json
@@ -1,79 +1,80 @@
 {
-  "name": "@papit/svg-spritesheet",
-  "description": "a simple tool that will merge multiple svg files into one ",
-  "keywords": [
-    "papit",
-    "node",
-    "typescript",
-    "svg-spritesheet"
-  ],
-  "version": "0.0.1",
-  "scripts": {
-    "build": "npx @papit/build -- --error --ancestors",
-    "watch": "tsc -w",
-    "start": "npm run build -- --dev && node ./lib/bundle.js",
-    "test": "node --test tests/**/*.test.js",
-    "preversion": "papit-version",
-    "postversion": "papit-version",
-    "component": "npm create @papit -- --component"
-  },
-  "main": "./lib/bundle.js",
-  "types": "./lib/bundle.d.ts",
-  "type": "module",
-  "files": [
-    "asset/",
-    "lib/"
-  ],
-  "exports": {
-    ".": {
-      "import": "./lib/bundle.js",
-      "types": "./lib/bundle.d.ts"
-    }
-  },
-  "bin": {
-    "papit-svg-spritesheet": "./lib/bundle.js"
-  },
-  "author": "henry",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "license": "LicenseRef-Papit-1.0",
-  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/svg-spritesheet",
-  "bugs": {
-    "url": "https://github.com/onkelhoy/papit/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/onkelhoy/papit.git",
-    "directory": "packages/runtime/svg-spritesheet"
-  },
-  "sideEffects": true,
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {
-    "@papit/arguments": "0.0.1",
-    "@papit/html": "0.0.1"
-  },
-  "devDependencies": {
-    "@types/node": "22.10.2",
-    "typescript": "5.9.3"
-  },
-  "browserslist": [
-    "defaults",
-    "not IE 11",
-    "not dead"
-  ],
-  "papit": {
-    "publish": true,
-    "type": "node",
-    "main": "svg-spritesheet",
-    "components": {
-      "svg-spritesheet": {
-        "className": "Svg-spritesheet"
-      }
-    }
-  }
+    "name": "@papit/svg-spritesheet",
+    "description": "a simple tool that will merge multiple svg files into one ",
+    "keywords": [
+        "papit",
+        "node",
+        "typescript",
+        "svg-spritesheet"
+    ],
+    "version": "0.0.1",
+    "scripts": {
+        "build": "npx @papit/build -- --error --ancestors",
+        "watch": "tsc -w",
+        "start": "npm run build -- --dev && node ./lib/bundle.js",
+        "test": "node --test tests/**/*.test.js",
+        "preversion": "papit-version",
+        "postversion": "papit-version",
+        "component": "npm create @papit -- --component"
+    },
+    "main": "./lib/bundle.js",
+    "types": "./lib/bundle.d.ts",
+    "type": "module",
+    "files": [
+        "asset/",
+        "lib/"
+    ],
+    "exports": {
+        ".": {
+            "import": "./lib/bundle.js",
+            "types": "./lib/bundle.d.ts"
+        }
+    },
+    "bin": {
+        "papit-svg-spritesheet": "./lib/bundle.js"
+    },
+    "author": "henry",
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
+    "license": "LicenseRef-Papit-1.0",
+    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/svg-spritesheet",
+    "bugs": {
+        "url": "https://github.com/onkelhoy/papit/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/onkelhoy/papit.git",
+        "directory": "packages/runtime/svg-spritesheet"
+    },
+    "sideEffects": true,
+    "engines": {
+        "node": ">=18"
+    },
+    "dependencies": {
+        "@papit/arguments": "0.0.1",
+        "@papit/html": "0.0.1"
+    },
+    "devDependencies": {
+        "@types/node": "22.10.2",
+        "typescript": "5.9.3"
+    },
+    "browserslist": [
+        "defaults",
+        "not IE 11",
+        "not dead"
+    ],
+    "papit": {
+        "publish": true,
+        "type": "node",
+        "main": "svg-spritesheet",
+        "components": {
+            "svg-spritesheet": {
+                "className": "Svg-spritesheet"
+            }
+        }
+    },
+    "remoteVersion": "0.0.1"
 }

--- a/packages/web/tools/signals/package.json
+++ b/packages/web/tools/signals/package.json
@@ -85,5 +85,6 @@
                 "htmlprefix": "pap"
             }
         }
-    }
+    },
+    "remoteVersion": "0.0.1"
 }


### PR DESCRIPTION
issue: #71

note: build with remote requires more attention as we still need to build ancestors

changelog:

- drop: ci flag from publish

- fix: cleanup build

- fix: introduce bin for build

- fix: build without --run-build flag

- clean: supress prebuild extra logs

- fix: imrpove version sync and reset

- fix: sync remote

- clean: no console in fetch

- fix: default should ignore global, 24h refresh it seems that npm has