### PR TITLE
feature/98-drawer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,70 @@
                 "node": ">=20"
             }
         },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+            "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+            "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+            "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+            "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/darwin-arm64": {
             "version": "0.27.2",
             "cpu": [
@@ -38,6 +102,342 @@
             "optional": true,
             "os": [
                 "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+            "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+            "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+            "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+            "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+            "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+            "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+            "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+            "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+            "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+            "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+            "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+            "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+            "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+            "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+            "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+            "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+            "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+            "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
             ],
             "engines": {
                 "node": ">=18"
@@ -134,6 +534,10 @@
         },
         "node_modules/@papit/dialog": {
             "resolved": "packages/web/design-system/atoms/dialog",
+            "link": true
+        },
+        "node_modules/@papit/drawer": {
+            "resolved": "packages/web/design-system/molecules/drawer",
             "link": true
         },
         "node_modules/@papit/field": {
@@ -775,7 +1179,7 @@
         },
         "packages/algorithms/data-structure": {
             "name": "@papit/data-structure",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "LicenseRef-Papit-1.0",
             "devDependencies": {
                 "@papit/bundle-js": "0.0.2",
@@ -891,14 +1295,14 @@
         },
         "packages/runtime/cli/build": {
             "name": "@papit/build",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
                 "@papit/arguments": "0.0.1",
                 "@papit/bundle-js": "0.0.2",
                 "@papit/bundle-ts": "0.0.1",
-                "@papit/data-structure": "0.0.1",
-                "@papit/information": "0.0.6",
+                "@papit/data-structure": "0.0.2",
+                "@papit/information": "0.0.7",
                 "@papit/terminal": "0.0.2"
             },
             "bin": {
@@ -971,15 +1375,40 @@
                 "node": ">=18"
             }
         },
-        "packages/runtime/cli/information": {
-            "name": "@papit/information",
+        "packages/runtime/cli/create/node_modules/@papit/data-structure": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@papit/data-structure/-/data-structure-0.0.1.tgz",
+            "integrity": "sha512-Jtx22gJjfzQxUUNxEzSx6L3ZxJ5eFN0JyDk3aJPbKrOXicwF24oKSBc97ffellefSe5llNMtI4QYLDP7PpRr/Q==",
+            "license": "LicenseRef-Papit-1.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/runtime/cli/create/node_modules/@papit/information": {
             "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@papit/information/-/information-0.0.6.tgz",
+            "integrity": "sha512-bdyj82ZLUOncWss/cRmwp63NCbkD5t/POyGsYPwrdnMkL5CH/ppu0qbNjIIyADYhGX74zjfIp3qJcUhQqVcQ4Q==",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
                 "@papit/arguments": "0.0.1",
                 "@papit/bundle-js": "0.0.2",
                 "@papit/bundle-ts": "0.0.1",
                 "@papit/data-structure": "0.0.1",
+                "@papit/terminal": "0.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/runtime/cli/information": {
+            "name": "@papit/information",
+            "version": "0.0.7",
+            "license": "LicenseRef-Papit-1.0",
+            "dependencies": {
+                "@papit/arguments": "0.0.1",
+                "@papit/bundle-js": "0.0.2",
+                "@papit/bundle-ts": "0.0.1",
+                "@papit/data-structure": "0.0.2",
                 "@papit/terminal": "0.0.2"
             },
             "devDependencies": {
@@ -992,15 +1421,15 @@
         },
         "packages/runtime/cli/server": {
             "name": "@papit/server",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
                 "@papit/arguments": "0.0.1",
-                "@papit/build": "0.0.5",
+                "@papit/build": "0.0.6",
                 "@papit/bundle-js": "0.0.2",
                 "@papit/deep-merge": "0.0.1",
                 "@papit/html": "0.0.1",
-                "@papit/information": "0.0.6",
+                "@papit/information": "0.0.7",
                 "@papit/terminal": "0.0.2",
                 "chokidar": "^5.0.0",
                 "esbuild": "0.27.2"
@@ -1030,11 +1459,11 @@
         },
         "packages/runtime/cli/version": {
             "name": "@papit/version",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
                 "@papit/arguments": "0.0.1",
-                "@papit/information": "0.0.6",
+                "@papit/information": "0.0.7",
                 "@papit/terminal": "0.0.2"
             },
             "bin": {
@@ -1102,7 +1531,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "*",
                 "@playwright/test": "1.58.0",
@@ -1115,13 +1544,13 @@
         },
         "packages/web/design-system/1-foundations/field": {
             "name": "@papit/field",
-            "version": "0.0.1",
+            "version": "0.1.0",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
-                "@papit/web-component": "*"
+                "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "*",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "*",
                 "@papit/translator": "^0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1140,7 +1569,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1159,7 +1588,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1178,7 +1607,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1198,7 +1627,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1220,7 +1649,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1242,7 +1671,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "*",
                 "@papit/translator": "^0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1255,16 +1684,37 @@
         },
         "packages/web/design-system/atoms/dialog": {
             "name": "@papit/dialog",
-            "version": "0.0.7",
+            "version": "0.0.8",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
                 "@papit/icon": "0.1.5",
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
+                "@playwright/test": "1.58.0",
+                "playwright": "1.58.0",
+                "typescript": "5.9.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/web/design-system/atoms/drawer": {
+            "name": "@papit/drawer",
+            "version": "0.0.1",
+            "extraneous": true,
+            "license": "LicenseRef-Papit-1.0",
+            "dependencies": {
+                "@papit/dialog": "^0.0.7",
+                "@papit/web-component": "0.0.6"
+            },
+            "devDependencies": {
+                "@papit/codeblock": "0.1.7",
+                "@papit/theme": "*",
+                "@papit/translator": "*",
                 "@playwright/test": "1.58.0",
                 "playwright": "1.58.0",
                 "typescript": "5.9.3"
@@ -1283,7 +1733,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "*",
                 "@papit/translator": "^0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1304,7 +1754,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1323,7 +1773,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/group": "0.0.6",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
@@ -1343,7 +1793,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1362,7 +1812,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1383,7 +1833,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1403,7 +1853,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1416,10 +1866,10 @@
         },
         "packages/web/design-system/molecules/codeblock": {
             "name": "@papit/codeblock",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "license": "LicenseRef-Papit-1.0",
             "dependencies": {
-                "@papit/data-structure": "0.0.1",
+                "@papit/data-structure": "0.0.2",
                 "@papit/icon": "0.1.5",
                 "@papit/lexer": "0.0.1",
                 "@papit/splitter": "0.0.6",
@@ -1430,6 +1880,26 @@
             "devDependencies": {
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
+                "@playwright/test": "1.58.0",
+                "playwright": "1.58.0",
+                "typescript": "5.9.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/web/design-system/molecules/drawer": {
+            "name": "@papit/drawer",
+            "version": "0.0.1",
+            "license": "LicenseRef-Papit-1.0",
+            "dependencies": {
+                "@papit/dialog": "0.0.8",
+                "@papit/web-component": "0.0.6"
+            },
+            "devDependencies": {
+                "@papit/codeblock": "0.1.7",
+                "@papit/theme": "*",
+                "@papit/translator": "*",
                 "@playwright/test": "1.58.0",
                 "playwright": "1.58.0",
                 "typescript": "5.9.3"
@@ -1449,7 +1919,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "0.0.2",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
@@ -1466,8 +1936,8 @@
             "license": "LicenseRef-Papit-1.0",
             "devDependencies": {
                 "@papit/arguments": "0.0.1",
-                "@papit/codeblock": "0.1.6",
-                "@papit/information": "0.0.6",
+                "@papit/codeblock": "0.1.7",
+                "@papit/information": "0.0.7",
                 "@papit/translator": "0.1.0",
                 "@playwright/test": "1.58.0",
                 "playwright": "1.58.0",
@@ -1505,6 +1975,16 @@
                 "@papit/tooltip": "0.0.3",
                 "@papit/web-component": "0.0.4"
             },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/web/themes/theme/node_modules/@papit/data-structure": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@papit/data-structure/-/data-structure-0.0.1.tgz",
+            "integrity": "sha512-Jtx22gJjfzQxUUNxEzSx6L3ZxJ5eFN0JyDk3aJPbKrOXicwF24oKSBc97ffellefSe5llNMtI4QYLDP7PpRr/Q==",
+            "dev": true,
+            "license": "LicenseRef-Papit-1.0",
             "engines": {
                 "node": ">=18"
             }
@@ -1621,7 +2101,7 @@
                 "@papit/web-component": "0.0.6"
             },
             "devDependencies": {
-                "@papit/codeblock": "0.1.6",
+                "@papit/codeblock": "0.1.7",
                 "@papit/theme": "*",
                 "@papit/translator": "*",
                 "@playwright/test": "1.58.0",
@@ -1676,6 +2156,16 @@
                 "@papit/tooltip": "0.0.3",
                 "@papit/web-component": "0.0.4"
             },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/web/tools/translator/node_modules/@papit/data-structure": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@papit/data-structure/-/data-structure-0.0.1.tgz",
+            "integrity": "sha512-Jtx22gJjfzQxUUNxEzSx6L3ZxJ5eFN0JyDk3aJPbKrOXicwF24oKSBc97ffellefSe5llNMtI4QYLDP7PpRr/Q==",
+            "dev": true,
+            "license": "LicenseRef-Papit-1.0",
             "engines": {
                 "node": ">=18"
             }

--- a/packages/algorithms/data-structure/package.json
+++ b/packages/algorithms/data-structure/package.json
@@ -1,80 +1,80 @@
 {
-    "name": "@papit/data-structure",
-    "description": "A collection of data models not existing in JavaScript",
-    "keywords": [
-        "papit",
-        "node",
-        "typescript",
-        "data-structure"
-    ],
-    "version": "0.0.1",
-    "scripts": {
-        "prebuild": "node bin/prebuild.mjs",
-        "build": "npx @papit/build -- --error --ancestors",
-        "watch": "tsc -w",
-        "start": "npm run build -- --dev && node ./lib/bundle.js",
-        "test": "node --test tests/**/*.test.js",
-        "test:only": "node --test --test-only tests/**/*.test.js",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit -- --component"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/algorithms/data-structure",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/algorithms/data-structure"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {},
-    "devDependencies": {
-        "@types/node": "22.10.2",
-        "typescript": "5.9.3",
-        "@papit/bundle-ts": "0.0.1",
-        "@papit/bundle-js": "0.0.2"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "node",
-        "main": "data-structure",
-        "priority": 1,
-        "components": {
-            "data-structure": {
-                "className": "DataModels",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.1"
+  "name": "@papit/data-structure",
+  "description": "A collection of data models not existing in JavaScript",
+  "keywords": [
+    "papit",
+    "node",
+    "typescript",
+    "data-structure"
+  ],
+  "version": "0.0.2",
+  "scripts": {
+    "prebuild": "node bin/prebuild.mjs",
+    "build": "npx @papit/build -- --error --ancestors",
+    "watch": "tsc -w",
+    "start": "npm run build -- --dev && node ./lib/bundle.js",
+    "test": "node --test tests/**/*.test.js",
+    "test:only": "node --test --test-only tests/**/*.test.js",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit -- --component"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/algorithms/data-structure",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/algorithms/data-structure"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "22.10.2",
+    "typescript": "5.9.3",
+    "@papit/bundle-ts": "0.0.1",
+    "@papit/bundle-js": "0.0.2"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "node",
+    "main": "data-structure",
+    "priority": 1,
+    "components": {
+      "data-structure": {
+        "className": "DataModels",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.1"
 }

--- a/packages/algorithms/data-structure/src/graph.ts
+++ b/packages/algorithms/data-structure/src/graph.ts
@@ -1,44 +1,171 @@
-export class GraphNode<T> {
-    edges: Set<GraphNode<T>> = new Set();
-    constructor(public value: T) { }
+import { Queue } from "queue";
+
+class Node<ID = string> {
+    constructor(
+        public id: ID
+    ) { }
 }
 
-export class Graph<T> {
-    nodes: Map<T, GraphNode<T>> = new Map();
+class Edge<Type, ID> {
+    constructor(
+        public type: Type,
+        public from: ID,
+        public to: ID,
+    ) { }
+}
 
-    addNode(value: T): GraphNode<T> {
-        if (!this.nodes.has(value))
+class Graph<N extends Node<ID>, ID = string, EdgeType = string> {
+
+    nodes: Map<ID, N> = new Map();
+    edges: Edge<EdgeType, ID>[] = [];
+    outgoing: Map<ID, Edge<EdgeType, ID>[]> = new Map();
+    incoming: Map<ID, Edge<EdgeType, ID>[]> = new Map();
+
+    constructor(
+        private strict = true
+    ) { }
+
+    get(id: ID) { return this.nodes.get(id) }
+
+    addNode(node: N): this {
+        this.nodes.set(node.id, node);
+        return this;
+    }
+
+    subgraph(ids: ID[]): Graph<N, ID, EdgeType> {
+        const set = new Set(ids);
+        const sub = new Graph<N, ID, EdgeType>(this.strict);
+
+        for (const id of ids)
         {
-            this.nodes.set(value, new GraphNode(value));
-        }
-        return this.nodes.get(value)!;
-    }
-
-    addEdge(from: T, to: T) {
-        const fromNode = this.addNode(from);
-        const toNode = this.addNode(to);
-        fromNode.edges.add(toNode);
-    }
-
-    // Topological sort (returns nodes in dependency order)
-    topologicalSort(): T[] {
-        const visited = new Set<GraphNode<T>>();
-        const temp = new Set<GraphNode<T>>();
-        const result: T[] = [];
-
-        const visit = (node: GraphNode<T>) => {
-            if (temp.has(node)) throw new Error("Cycle detected");
-            if (!visited.has(node))
+            const node = this.nodes.get(id);
+            if (node)
             {
-                temp.add(node);
-                node.edges.forEach(visit);
-                temp.delete(node);
-                visited.add(node);
-                result.push(node.value);
+                sub.nodes.set(id, node);
+            }
+        }
+
+        for (const edge of this.edges)
+        {
+            if (set.has(edge.from) && set.has(edge.to))
+            {
+                sub.addEdge(edge.from, edge.to, edge.type);
+            }
+        }
+
+        return sub;
+    }
+
+    addEdge(from: ID, to: ID, type: EdgeType) {
+        const fromNode = this.get(from);
+        const toNode = this.get(to);
+
+        if (!fromNode) throw new Error("from node does not exist");
+        if (!toNode) throw new Error("to node does not exist");
+
+        const edge = new Edge(type, from, to);
+
+        this.edges.push(edge);
+
+        if (!this.outgoing.has(from)) this.outgoing.set(from, []);
+        if (!this.incoming.has(to)) this.incoming.set(to, []);
+
+        this.outgoing.get(from)!.push(edge);
+        this.incoming.get(to)!.push(edge);
+    }
+
+    private bfs(direction: "outgoing" | "incoming", start: ID, typeFilter?: EdgeType[]): N[] {
+        const visited = new Set<ID>();
+        const queue: ID[] = [start];
+        const result: N[] = [];
+
+        visited.add(start);
+
+        while (queue.length > 0)
+        {
+            const current = queue.shift()!;
+            const edges = this[direction].get(current) ?? [];
+
+            for (const edge of edges)
+            {
+                if (typeFilter && !typeFilter.includes(edge.type)) continue;
+
+                const next = direction === "outgoing" ? edge.to : edge.from;
+                if (visited.has(next)) continue;
+
+                visited.add(next);
+                queue.push(next);
+                result.push(this.get(next)!);
+            }
+        }
+
+        return result;
+    }
+
+    toposort(typeFilter?: EdgeType[]) {
+        const visited = new Set<ID>();
+        const visiting = new Set<ID>();
+        const result: ID[] = [];
+
+        const visit = (id: ID) => {
+            if (visited.has(id)) return;
+
+            if (visiting.has(id))
+            {
+                // Cycle detected
+                if (!this.strict)
+                {
+                    // In non-strict mode, still add the node but skip further processing
+                    if (!visited.has(id))
+                    {
+                        visited.add(id);
+                        result.push(id);
+                    }
+                    return;
+                }
+                throw new Error("Cycle detected");
+            }
+
+            visiting.add(id);
+
+            for (const edge of this.outgoing.get(id) ?? [])
+            {
+                if (typeFilter && !typeFilter.includes(edge.type)) continue;
+                visit(edge.to);
+            }
+
+            visiting.delete(id);
+
+            if (!visited.has(id))
+            {
+                visited.add(id);
+                result.push(id);
             }
         };
 
-        this.nodes.forEach(visit);
-        return result.reverse(); // dependencies first
+        for (const id of this.nodes.keys())
+        {
+            if (!visited.has(id))
+            {
+                visit(id);
+            }
+        }
+
+        return result.reverse();
     }
+
+    descendants(start: ID, typeFilter?: EdgeType[]): N[] {
+        return this.bfs("outgoing", start, typeFilter);
+    }
+
+    ancestors(start: ID, typeFilter?: EdgeType[]): N[] {
+        return this.bfs("incoming", start, typeFilter);
+    }
+}
+
+
+export {
+    Graph,
+    Edge as GraphEdge,
+    Node as GraphNode,
 }

--- a/packages/algorithms/data-structure/src/linked-list.ts
+++ b/packages/algorithms/data-structure/src/linked-list.ts
@@ -54,10 +54,19 @@ export class LinkedList<T> implements ILinkedList<T, ListNode<T>> {
     }
 
     append(value: T): void {
-        const node = this.create(value);
+        const node = new ListNode<T>(value);
 
-        this.rear!.next = node;
-        this.rear = node;
+        if (!this.front)
+        {
+            // First node
+            this.front = node;
+            this.rear = node;
+        } else
+        {
+            // Add to end
+            this.rear!.next = node;
+            this.rear = node;
+        }
         this._size++;
     }
     insert(value: T, target?: T | undefined): void {

--- a/packages/algorithms/data-structure/tests/graph.test.js
+++ b/packages/algorithms/data-structure/tests/graph.test.js
@@ -1,63 +1,199 @@
 import {describe, it, beforeEach} from "node:test";
 import assert from "node:assert";
-import {Graph} from "@papit/data-structure"; // adjust path
+import {Graph, GraphNode} from "@papit/data-structure";
 
-describe("DependencyGraph", () => {
+function makeGraph() {
+    return new Graph();
+}
+
+function add(graph, ...ids) {
+    for (const id of ids) graph.addNode(new GraphNode(id));
+}
+
+describe("Graph", () => {
     let graph;
 
-    beforeEach(() => {
-        graph = new Graph();
+    beforeEach(() => {graph = makeGraph()});
+
+    describe("nodes", () => {
+        it("should add nodes", () => {
+            add(graph, "A", "B");
+            assert.ok(graph.nodes.has("A"));
+            assert.ok(graph.nodes.has("B"));
+            assert.equal(graph.nodes.size, 2);
+        });
+
+        it("should return node by id", () => {
+            add(graph, "A");
+            assert.equal(graph.get("A")?.id, "A");
+            assert.equal(graph.get("Z"), undefined);
+        });
     });
 
-    it("should add nodes without edges", () => {
-        graph.addNode("A");
-        graph.addNode("B");
+    describe("edges", () => {
+        it("should add edges and populate outgoing/incoming maps", () => {
+            add(graph, "A", "B");
+            // B is a dependency of A: edge B → A
+            graph.addEdge("B", "A", "dependency");
 
-        assert.ok(graph.nodes.has("A"));
-        assert.ok(graph.nodes.has("B"));
-        assert.equal(graph.nodes.get("A").edges.size, 0);
-        assert.equal(graph.nodes.get("B").edges.size, 0);
+            assert.equal(graph.edges.length, 1);
+            assert.equal(graph.outgoing.get("B")?.length, 1);
+            assert.equal(graph.incoming.get("A")?.length, 1);
+            assert.equal(graph.outgoing.get("A"), undefined);
+        });
+
+        it("should throw when from-node is missing", () => {
+            add(graph, "A");
+            assert.throws(() => graph.addEdge("Z", "A", "dependency"), /from node does not exist/);
+        });
+
+        it("should throw when to-node is missing", () => {
+            add(graph, "A");
+            assert.throws(() => graph.addEdge("A", "Z", "dependency"), /to node does not exist/);
+        });
+
+        it("should filter by edge type in outgoing lookup", () => {
+            add(graph, "A", "B", "C");
+            graph.addEdge("B", "A", "dependency");
+            graph.addEdge("C", "A", "peer");
+
+            const depEdges = (graph.outgoing.get("B") ?? []).filter(e => e.type === "dependency");
+            const peerEdges = (graph.outgoing.get("C") ?? []).filter(e => e.type === "peer");
+            assert.equal(depEdges.length, 1);
+            assert.equal(peerEdges.length, 1);
+        });
     });
 
-    it("should add edges correctly", () => {
-        graph.addEdge("A", "B");
-        graph.addEdge("A", "C");
+    describe("toposort", () => {
+        it("should return all nodes for disconnected graph", () => {
+            add(graph, "X", "Y", "Z");
+            const order = graph.toposort();
+            assert.equal(order.length, 3);
+            assert.ok(order.includes("X"));
+            assert.ok(order.includes("Y"));
+            assert.ok(order.includes("Z"));
+        });
 
-        const a = graph.nodes.get("A");
-        assert.ok(a.edges.has(graph.nodes.get("B")));
-        assert.ok(a.edges.has(graph.nodes.get("C")));
-        assert.equal(graph.nodes.size, 3); // A, B, C
+        it("should place dependencies before dependents", () => {
+            // D ← B ← A, D ← C ← A  (D is a dep of B and C, B/C are deps of A)
+            add(graph, "A", "B", "C", "D");
+            graph.addEdge("D", "B", "dependency");
+            graph.addEdge("D", "C", "dependency");
+            graph.addEdge("B", "A", "dependency");
+            graph.addEdge("C", "A", "dependency");
+
+            const order = graph.toposort();
+            assert.ok(order.indexOf("D") < order.indexOf("B"), "D before B");
+            assert.ok(order.indexOf("D") < order.indexOf("C"), "D before C");
+            assert.ok(order.indexOf("B") < order.indexOf("A"), "B before A");
+            assert.ok(order.indexOf("C") < order.indexOf("A"), "C before A");
+        });
+
+        it("should detect cycles", () => {
+            add(graph, "A", "B", "C");
+            graph.addEdge("A", "B", "dependency");
+            graph.addEdge("B", "C", "dependency");
+            graph.addEdge("C", "A", "dependency");
+
+            assert.throws(() => graph.toposort(), /Cycle detected/);
+        });
+
+        it("should respect typeFilter — ignored edge types do not affect order", () => {
+            add(graph, "A", "B", "C");
+            // B is a hard dep of A
+            graph.addEdge("B", "A", "dependency");
+            // C is only a peer dep of A — excluded by filter
+            graph.addEdge("C", "A", "peer");
+
+            const order = graph.toposort(["dependency"]);
+            assert.ok(order.indexOf("B") < order.indexOf("A"), "B before A");
+            // C is still in the result (it's a node), just unconstrained
+            assert.ok(order.includes("C"));
+        });
     });
 
-    it.skip("should perform topological sort in dependency order", () => { // THIS FAILS 
-        graph.addEdge("A", "B");
-        graph.addEdge("A", "C");
-        graph.addEdge("B", "D");
-        graph.addEdge("C", "D");
+    describe("ancestors / descendants", () => {
+        // Dependency chain: D ← B ← A  and  D ← C ← A
+        // Edge direction: dependency → dependent
+        beforeEach(() => {
+            add(graph, "A", "B", "C", "D");
+            graph.addEdge("D", "B", "dependency"); // B depends on D
+            graph.addEdge("D", "C", "dependency"); // C depends on D
+            graph.addEdge("B", "A", "dependency"); // A depends on B
+            graph.addEdge("C", "A", "dependency"); // A depends on C
+        });
 
-        const order = graph.topologicalSort();
+        it("ancestors(A) = all things A depends on transitively", () => {
+            const anc = graph.ancestors("A").map(n => n.id);
+            assert.ok(anc.includes("B"), "B");
+            assert.ok(anc.includes("C"), "C");
+            assert.ok(anc.includes("D"), "D");
+            assert.equal(anc.length, 3);
+        });
 
-        // D must come before B and C, B/C before A
-        assert.ok(order.indexOf("D") < order.indexOf("B"));
-        assert.ok(order.indexOf("D") < order.indexOf("C"));
-        assert.ok(order.indexOf("B") < order.indexOf("A"));
-        assert.ok(order.indexOf("C") < order.indexOf("A"));
+        it("ancestors(D) = nothing (D has no dependencies)", () => {
+            assert.equal(graph.ancestors("D").length, 0);
+        });
+
+        it("descendants(D) = everything that depends on D transitively", () => {
+            const desc = graph.descendants("D").map(n => n.id);
+            assert.ok(desc.includes("B"), "B");
+            assert.ok(desc.includes("C"), "C");
+            assert.ok(desc.includes("A"), "A");
+            assert.equal(desc.length, 3);
+        });
+
+        it("descendants(A) = nothing (nothing depends on A)", () => {
+            assert.equal(graph.descendants("A").length, 0);
+        });
+
+        it("typeFilter excludes edges of wrong type", () => {
+            add(graph, "E");
+            graph.addEdge("E", "A", "peer"); // only peer, not dependency
+
+            const anc = graph.ancestors("A", ["dependency"]).map(n => n.id);
+            assert.ok(!anc.includes("E"), "E excluded by filter");
+        });
     });
 
-    it("should detect cycles", () => {
-        graph.addEdge("A", "B");
-        graph.addEdge("B", "C");
-        graph.addEdge("C", "A"); // creates cycle
+    describe("subgraph", () => {
+        beforeEach(() => {
+            add(graph, "A", "B", "C", "D");
+            graph.addEdge("D", "C", "dependency");
+            graph.addEdge("C", "B", "dependency");
+            graph.addEdge("B", "A", "dependency");
+        });
 
-        assert.throws(() => graph.topologicalSort(), /Cycle detected/);
-    });
+        it("should include only specified nodes", () => {
+            const sub = graph.subgraph(["A", "B", "C"]);
+            assert.ok(sub.nodes.has("A"));
+            assert.ok(sub.nodes.has("B"));
+            assert.ok(sub.nodes.has("C"));
+            assert.ok(!sub.nodes.has("D"));
+        });
 
-    it("should handle disconnected nodes", () => {
-        graph.addNode("X");
-        graph.addNode("Y");
+        it("should include only edges between nodes in the set", () => {
+            const sub = graph.subgraph(["A", "B", "C"]);
+            // C→B and B→A are in set, D→C is not
+            assert.equal(sub.edges.length, 2);
+        });
 
-        const order = graph.topologicalSort();
-        assert.ok(order.includes("X"));
-        assert.ok(order.includes("Y"));
+        it("subgraph toposort respects internal edges only", () => {
+
+            const descendants = graph.descendants("D");
+            const desc = descendants.map(n => n.id).concat("D");
+            const sub = graph.subgraph(desc);
+            const order = sub.toposort();
+
+            assert.ok(order.indexOf("D") < order.indexOf("C"), "D before C");
+            assert.ok(order.indexOf("C") < order.indexOf("B"), "C before B");
+            assert.ok(order.indexOf("B") < order.indexOf("A"), "B before A");
+        });
+
+        it("should handle unknown ids gracefully", () => {
+            const sub = graph.subgraph(["A", "NOPE"]);
+            assert.ok(sub.nodes.has("A"));
+            assert.ok(!sub.nodes.has("NOPE"));
+        });
     });
 });

--- a/packages/network/signal-server/src/socket.ts
+++ b/packages/network/signal-server/src/socket.ts
@@ -5,249 +5,254 @@ import { performance } from 'node:perf_hooks';
 // import types
 import { Socket, NetworkInfo } from './types/socket';
 import {
-  IncomingMessage,
-  IncomingMessageType,
-  Message,
-  MessageType,
-  NetworkMessage,
-  OutgoingMessage,
-  OutgoingMessageType,
-  TargetMessage
+    IncomingMessage,
+    IncomingMessageType,
+    Message,
+    MessageType,
+    NetworkMessage,
+    OutgoingMessage,
+    OutgoingMessageType,
+    TargetMessage
 } from './types/message';
 
 export interface ServerOptions extends ws.ServerOptions {
-  setClientID?(request: http.IncomingMessage): string;
-  heartbeat_interval?: number;
-  spam_duration?: number;
-  spam_reset?: number;
-  strikes?: number;
+    setClientID?(request: http.IncomingMessage): string;
+    heartbeat_interval?: number;
+    spam_duration?: number;
+    spam_reset?: number;
+    strikes?: number;
 }
 
 export class SocketServer extends ws.WebSocketServer {
-  private heartbeat_timer: NodeJS.Timeout;
+    private heartbeat_timer: NodeJS.Timeout;
 
-  public sockets!: Map<string, Socket>;
-  public networks!: Map<string, NetworkInfo>;
-  public hosts!: Map<string, string[]>;
-  declare public options: ServerOptions;
+    public sockets!: Map<string, Socket>;
+    public networks!: Map<string, NetworkInfo>;
+    public hosts!: Map<string, string[]>;
+    declare public options: ServerOptions;
 
-  constructor(options: ServerOptions, callback?: (() => void) | undefined) {
-    super(options, callback);
-    this.networks = new Map();
-    this.sockets = new Map();
-    this.hosts = new Map();
+    constructor(options: ServerOptions, callback?: (() => void) | undefined) {
+        super(options, callback);
+        this.networks = new Map();
+        this.sockets = new Map();
+        this.hosts = new Map();
 
-    this.on('connection', (socket: Socket, request) => {
-      this.welcome(socket, request);
+        this.on('connection', (socket: Socket, request) => {
+            this.welcome(socket, request);
 
-      socket.onmessage = this.onclientmessage();
-      socket.onclose = this.onclientclose();
-      socket.on("pong", function () {
+            socket.onmessage = this.onclientmessage();
+            socket.onclose = this.onclientclose();
+            socket.on("pong", function () {
+                socket.is_alive = true;
+            })
+        });
+
+        this.on("error", (err) => {
+            this.printerror(err.message);
+        });
+
+        // heartbeat
+        this.heartbeat_timer = setInterval(() => {
+            this.clients.forEach(wssocket => {
+                const socket = wssocket as Socket;
+                if (!socket.is_alive)
+                {
+                    socket.close();
+                }
+                else
+                {
+                    socket.is_alive = false;
+                    socket.ping();
+                }
+            });
+        }, this.options.heartbeat_interval || 2000);
+    }
+
+    private onclientmessage() {
+        const wss = this;
+        return function (this: Socket, event: ws.MessageEvent) {
+            if (wss.spamcheck(this))
+            {
+                wss.printerror(`socket ${this.id} is spamming server`);
+                this.close();
+                return;
+            }
+
+            try
+            {
+                const message = JSON.parse(event.data as string) as IncomingMessage;
+                switch (message.type)
+                {
+                    case MessageType.Target: {
+                        const { target: targetid } = message as TargetMessage;
+                        const target = wss.sockets.get(targetid);
+
+                        if (target)
+                        {
+                            wss.send(target, message as OutgoingMessage);
+                        }
+                        else
+                        {
+                            wss.send(this, {
+                                type: OutgoingMessageType.Error,
+                                error: 'Target not found',
+                            } as OutgoingMessage);
+                        }
+                        break;
+                    }
+                    case IncomingMessageType.Update: {
+                        const { network } = message as NetworkMessage;
+                        const networkid = network.id || this.id;
+
+                        const targetnetwork = wss.networks.get(networkid);
+                        if (targetnetwork && targetnetwork.host === this.id)
+                        {
+                            const { network } = message as NetworkMessage;
+                            const updated: NetworkInfo = { ...targetnetwork, ...network, id: networkid, host: this.id };
+                            wss.networks.set(networkid, updated);
+
+                            // NOTE this is just extra
+                            wss.send(this, {
+                                type: OutgoingMessageType.UpdateACK,
+                                network: wss.networks.get(networkid),
+                            } as OutgoingMessage);
+                        }
+                        else
+                        {
+                            wss.send(this, {
+                                type: OutgoingMessageType.Error,
+                                error: 'Host not found',
+                            } as OutgoingMessage);
+                        }
+                        break;
+                    }
+                    case IncomingMessageType.Register: {
+                        const { network } = message as NetworkMessage;
+                        const networkid = network.id || this.id;
+
+                        if (!wss.networks.has(networkid))
+                        {
+                            wss.networks.set(networkid, { ...network, id: networkid, host: this.id });
+
+                            const networks = wss.hosts.get(this.id) || [];
+                            wss.hosts.set(this.id, [...networks, networkid]);
+
+                            // NOTE this is just extra
+                            wss.send(this, {
+                                type: OutgoingMessageType.RegisterACK,
+                                network: wss.networks.get(networkid),
+                            } as OutgoingMessage);
+                        }
+                        else
+                        {
+                            wss.send(this, {
+                                type: OutgoingMessageType.Error,
+                                error: 'Host already exists',
+                            } as OutgoingMessage);
+                        }
+                        break;
+                    }
+                    default: {
+                        wss.send(this, {
+                            type: OutgoingMessageType.Error,
+                            error: `unsupported message::${message.type}`
+                        } as OutgoingMessage);
+                    }
+                }
+            }
+            catch (error)
+            {
+                // NOTE this most likely failed at parse level
+                wss.send(this, {
+                    type: OutgoingMessageType.Error,
+                    error: 'something went wrong'
+                } as OutgoingMessage);
+            }
+        }
+    }
+    private onclientclose() {
+        const wss = this;
+        return function (this: Socket) {
+            wss.sockets.delete(this.id);
+
+            if (wss.hosts.has(this.id))
+            {
+                const networks = wss.hosts.get(this.id);
+                if (networks) networks.forEach(id => wss.networks.delete(id));
+                wss.hosts.delete(this.id);
+            }
+        }
+    }
+    private welcome(socket: Socket, request: http.IncomingMessage) {
         socket.is_alive = true;
-      })
-    });
-
-    this.on("error", (err) => {
-      this.printerror(err.message);
-    });
-
-    // heartbeat
-    this.heartbeat_timer = setInterval(() => {
-      this.clients.forEach(wssocket => {
-        const socket = wssocket as Socket;
-        if (!socket.is_alive)
-        {
-          socket.close();
-        }
-        else
-        {
-          socket.is_alive = false;
-          socket.ping();
-        }
-      });
-    }, this.options.heartbeat_interval || 2000);
-  }
-
-  private onclientmessage() {
-    const wss = this;
-    return function (this: Socket, event: ws.MessageEvent) {
-      if (wss.spamcheck(this))
-      {
-        wss.printerror(`socket ${this.id} is spamming server`);
-        this.close();
-        return;
-      }
-
-      try
-      {
-        const message = JSON.parse(event.data as string) as IncomingMessage;
-        switch (message.type)
-        {
-          case MessageType.Target: {
-            const { target: targetid } = message as TargetMessage;
-            const target = wss.sockets.get(targetid);
-
-            if (target)
-            {
-              wss.send(target, message as OutgoingMessage);
-            }
-            else
-            {
-              wss.send(this, {
-                type: OutgoingMessageType.Error,
-                error: 'Target not found',
-              } as OutgoingMessage);
-            }
-            break;
-          }
-          case IncomingMessageType.Update: {
-            const { network } = message as NetworkMessage;
-            const networkid = network.id || this.id;
-
-            const targetnetwork = wss.networks.get(networkid);
-            if (targetnetwork && targetnetwork.host === this.id)
-            {
-              const { network } = message as NetworkMessage;
-              const updated: NetworkInfo = { ...targetnetwork, ...network, id: networkid, host: this.id };
-              wss.networks.set(networkid, updated);
-
-              // NOTE this is just extra
-              wss.send(this, {
-                type: OutgoingMessageType.UpdateACK,
-                network: wss.networks.get(networkid),
-              } as OutgoingMessage);
-            }
-            else
-            {
-              wss.send(this, {
-                type: OutgoingMessageType.Error,
-                error: 'Host not found',
-              } as OutgoingMessage);
-            }
-            break;
-          }
-          case IncomingMessageType.Register: {
-            const { network } = message as NetworkMessage;
-            const networkid = network.id || this.id;
-
-            if (!wss.networks.has(networkid))
-            {
-              wss.networks.set(networkid, { ...network, id: networkid, host: this.id });
-
-              const networks = wss.hosts.get(this.id) || [];
-              wss.hosts.set(this.id, [...networks, networkid]);
-
-              // NOTE this is just extra
-              wss.send(this, {
-                type: OutgoingMessageType.RegisterACK,
-                network: wss.networks.get(networkid),
-              } as OutgoingMessage);
-            }
-            else
-            {
-              wss.send(this, {
-                type: OutgoingMessageType.Error,
-                error: 'Host already exists',
-              } as OutgoingMessage);
-            }
-            break;
-          }
-          default: {
-            wss.send(this, {
-              type: OutgoingMessageType.Error,
-              error: `unsupported message::${message.type}`
-            } as OutgoingMessage);
-          }
-        }
-      }
-      catch (error)
-      {
-        // NOTE this most likely failed at parse level
-        wss.send(this, {
-          type: OutgoingMessageType.Error,
-          error: 'something went wrong'
-        } as OutgoingMessage);
-      }
-    }
-  }
-  private onclientclose() {
-    const wss = this;
-    return function (this: Socket) {
-      wss.sockets.delete(this.id);
-
-      if (wss.hosts.has(this.id))
-      {
-        const networks = wss.hosts.get(this.id);
-        if (networks) networks.forEach(id => wss.networks.delete(id));
-        wss.hosts.delete(this.id);
-      }
-    }
-  }
-  private welcome(socket: Socket, request: http.IncomingMessage) {
-    socket.is_alive = true;
-    socket.id = this.getID(request);
-    socket.strike = 0;
-
-    this.sockets.set(socket.id, socket);
-    this.send(socket, {
-      type: OutgoingMessageType.ConnectionACK,
-      id: socket.id,
-    } as OutgoingMessage);
-  }
-  private spamcheck(socket: Socket): boolean {
-    const maxstrikes = (this.options.strikes || 5);
-    if (socket.lastmessage)
-    {
-      const duration = performance.now() - socket.lastmessage;
-      if (duration < (this.options.spam_duration || 200))
-      {
-        // user sent message before duration time has passed, user should have MAXSTRIKES strikes and then banned
-        socket.strike++;
-      }
-      else if (socket.strike < maxstrikes && duration >= (this.options.spam_reset || 1500))
-      {
+        socket.id = this.getID(request);
         socket.strike = 0;
-      }
+
+        if (this.sockets.has(socket.id))
+        {
+            this.sockets.get(socket.id)?.terminate();
+        }
+
+        this.sockets.set(socket.id, socket);
+        this.send(socket, {
+            type: OutgoingMessageType.ConnectionACK,
+            id: socket.id,
+        } as OutgoingMessage);
+    }
+    private spamcheck(socket: Socket): boolean {
+        const maxstrikes = (this.options.strikes || 5);
+        if (socket.lastmessage)
+        {
+            const duration = performance.now() - socket.lastmessage;
+            if (duration < (this.options.spam_duration || 200))
+            {
+                // user sent message before duration time has passed, user should have MAXSTRIKES strikes and then banned
+                socket.strike++;
+            }
+            else if (socket.strike < maxstrikes && duration >= (this.options.spam_reset || 1500))
+            {
+                socket.strike = 0;
+            }
+        }
+
+        socket.lastmessage = performance.now();
+        return socket.strike >= maxstrikes;
+    }
+    private printerror(error: string) {
+        console.log(
+            "socket server error",
+            performance.now(),
+            error,
+        );
+    }
+    private getID(req: http.IncomingMessage): string {
+        if (this.options.setClientID)
+            return this.options.setClientID(req);
+
+        return `${req.headers['user-agent']} ${req.socket.remoteAddress}`;
     }
 
-    socket.lastmessage = performance.now();
-    return socket.strike >= maxstrikes;
-  }
-  private printerror(error: string) {
-    console.log(
-      "socket server error",
-      performance.now(),
-      error,
-    );
-  }
-  private getID(req: http.IncomingMessage): string {
-    if (this.options.setClientID)
-      return this.options.setClientID(req);
-
-    return `${req.headers['user-agent']} ${req.socket.remoteAddress}`;
-  }
-
-  public send(target: Socket, message: OutgoingMessage): void {
-    const strmessage = JSON.stringify(message);
-    target.send(strmessage);
-  }
-  // NOTE this is mailt for testing purposes
-  public broadcast(message: OutgoingMessage): void {
-    const strmessage = JSON.stringify(message);
-    this.sockets.forEach(socket => {
-      // we dont need to send update to host clients
-      if (!this.hosts.has(socket.id))
-      {
-        socket.send(strmessage);
-      }
-    });
-  }
-  public close() {
-    for (const socket of this.clients)
-    {
-      socket.terminate();
+    public send(target: Socket, message: OutgoingMessage): void {
+        const strmessage = JSON.stringify(message);
+        target.send(strmessage);
     }
-    super.close();
-    clearInterval(this.heartbeat_timer);
-  }
+    // NOTE this is mailt for testing purposes
+    public broadcast(message: OutgoingMessage): void {
+        const strmessage = JSON.stringify(message);
+        this.sockets.forEach(socket => {
+            // we dont need to send update to host clients
+            if (!this.hosts.has(socket.id))
+            {
+                socket.send(strmessage);
+            }
+        });
+    }
+    public close() {
+        for (const socket of this.clients)
+        {
+            socket.terminate();
+        }
+        super.close();
+        clearInterval(this.heartbeat_timer);
+    }
 }

--- a/packages/runtime/cli/build/package.json
+++ b/packages/runtime/cli/build/package.json
@@ -1,91 +1,91 @@
 {
-    "name": "@papit/build",
-    "description": "Build tool for @papit packages — opinionated, fast, and designed to work seamlessly inside any Papit-based workspace.",
-    "keywords": [
-        "papit",
-        "node",
-        "typescript",
-        "build"
-    ],
-    "version": "0.0.5",
-    "scripts": {
-        "prebuild": "node bin/prebuild.mjs",
-        "build": "node lib/bin.js --error",
-        "watch": "tsc -w",
-        "start": "npm run build -- --dev && node ./lib/bin.js",
-        "test": "node --test tests/**/*.test.js",
-        "test:only": "node --test --test-only tests/**/*.test.js",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit -- --component"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "bin": {
-        "papit-build": "lib/bin.js"
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/build",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/runtime/cli/build"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/arguments": "0.0.1",
-        "@papit/data-structure": "0.0.1",
-        "@papit/information": "0.0.6",
-        "@papit/terminal": "0.0.2",
-        "@papit/bundle-ts": "0.0.1",
-        "@papit/bundle-js": "0.0.2"
-    },
-    "peerDependencies": {
-        "esbuild": "0.27.2",
-        "typescript": "5.9.3"
-    },
-    "devDependencies": {
-        "@types/node": "22.10.2"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "priority": 4,
-        "publish": true,
-        "type": "node",
-        "main": "build",
-        "components": {
-            "build": {
-                "className": "Build",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.5"
+  "name": "@papit/build",
+  "description": "Build tool for @papit packages — opinionated, fast, and designed to work seamlessly inside any Papit-based workspace.",
+  "keywords": [
+    "papit",
+    "node",
+    "typescript",
+    "build"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "prebuild": "node bin/prebuild.mjs",
+    "build": "node lib/bin.js --error",
+    "watch": "tsc -w",
+    "start": "npm run build -- --dev && node ./lib/bin.js",
+    "test": "node --test tests/**/*.test.js",
+    "test:only": "node --test --test-only tests/**/*.test.js",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit -- --component"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "bin": {
+    "papit-build": "lib/bin.js"
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/build",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/runtime/cli/build"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/arguments": "0.0.1",
+    "@papit/data-structure": "0.0.2",
+    "@papit/information": "0.0.7",
+    "@papit/terminal": "0.0.2",
+    "@papit/bundle-ts": "0.0.1",
+    "@papit/bundle-js": "0.0.2"
+  },
+  "peerDependencies": {
+    "esbuild": "0.27.2",
+    "typescript": "5.9.3"
+  },
+  "devDependencies": {
+    "@types/node": "22.10.2"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "priority": 4,
+    "publish": true,
+    "type": "node",
+    "main": "build",
+    "components": {
+      "build": {
+        "className": "Build",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.5"
 }

--- a/packages/runtime/cli/information/package.json
+++ b/packages/runtime/cli/information/package.json
@@ -1,83 +1,83 @@
 {
-    "name": "@papit/information",
-    "description": "Quite an abstract package to collect package information about other packages ",
-    "keywords": [
-        "papit",
-        "node",
-        "typescript",
-        "information"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "prebuild": "node bin/prebuild.mjs",
-        "build": "npx @papit/build -- --error --ancestors",
-        "watch": "tsc -w",
-        "start": "node ./lib/bundle.js",
-        "test": "node --test tests/**/*.test.js",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit -- --component"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/information",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/runtime/cli/information"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/arguments": "0.0.1",
-        "@papit/data-structure": "0.0.1",
-        "@papit/terminal": "0.0.2",
-        "@papit/bundle-js": "0.0.2",
-        "@papit/bundle-ts": "0.0.1"
-    },
-    "devDependencies": {
-        "typescript": "5.9.3",
-        "@types/node": "22.10.2"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "node",
-        "main": "information",
-        "priority": 3,
-        "components": {
-            "information": {
-                "className": "Information",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/information",
+  "description": "Quite an abstract package to collect package information about other packages ",
+  "keywords": [
+    "papit",
+    "node",
+    "typescript",
+    "information"
+  ],
+  "version": "0.0.7",
+  "scripts": {
+    "prebuild": "node bin/prebuild.mjs",
+    "build": "npx @papit/build -- --error --ancestors",
+    "watch": "tsc -w",
+    "start": "node ./lib/bundle.js",
+    "test": "node --test tests/**/*.test.js",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit -- --component"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/information",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/runtime/cli/information"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/arguments": "0.0.1",
+    "@papit/data-structure": "0.0.2",
+    "@papit/terminal": "0.0.2",
+    "@papit/bundle-js": "0.0.2",
+    "@papit/bundle-ts": "0.0.1"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3",
+    "@types/node": "22.10.2"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "node",
+    "main": "information",
+    "priority": 3,
+    "components": {
+      "information": {
+        "className": "Information",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/runtime/cli/information/src/graph.ts
+++ b/packages/runtime/cli/information/src/graph.ts
@@ -1,5 +1,7 @@
+// graph.ts
 import fs from "node:fs";
 import path from "node:path";
+import { Graph as BaseGraph, GraphNode } from "@papit/data-structure";
 import type { LocalPackage, Package, RootPackage } from "./types";
 import { PackageNode } from "./node";
 import { Cache } from "./cache";
@@ -7,20 +9,26 @@ import { Arguments } from "@papit/arguments";
 
 export class Graph {
     root!: PackageNode<RootPackage>;
+    private graph: BaseGraph<PackageNode, string, string>;
     private _nodes = new Map<string, PackageNode<LocalPackage>>();
 
-    get nodes() { return Array.from(this._nodes.values()) }
+    get nodes() {
+        // Filter root out for external API
+        return Array.from(this._nodes.values()); //.filter(node => node.type !== "root");
+    }
+
     get(name: string) { return this._nodes.get(name) as PackageNode<LocalPackage> }
+
     search(location: string, compare: "start" | "end" = "end") {
         if (compare === "end") return this.nodes.find(node => node.location.endsWith(location));
         return this.nodes.find(node => location.startsWith(node.location));
     }
 
     private scope = "";
-
     public ERROR = false;
 
     constructor() {
+        this.graph = new BaseGraph<PackageNode, string, string>(false);
         const location = process.cwd();
 
         try
@@ -37,31 +45,27 @@ export class Graph {
                 .filter(loc => {
                     if (!loc.endsWith("package.json")) return false;
                     if (/[/\\]asset[/\\]/i.test(loc)) return false;
-
                     return true;
                 })
-                .forEach((localFilePath, index, array) => {
+                .forEach((localFilePath) => {
                     const location = path.dirname(path.join(rootPATH, "packages", localFilePath));
-                    this.add(
-                        location,
-                        "local",
-                        leftovers,
-                    );
+                    this.add(location, "local", leftovers);
                 });
 
+            // Process leftovers (dependencies that weren't found yet)
             leftovers.forEach((dependants, name) => {
                 const node = this.get(name);
                 if (!node) return;
                 dependants.forEach(dep => {
                     const dnode = this.get(dep);
                     if (!dnode) return;
-                    node.children.push(dnode);
-                    dnode.parents.push(node);
-                })
+                    // Add edge in the graph
+                    this.graph.addEdge(node.name, dnode.name, "dependency");
+                });
             });
-        }
-        catch
+        } catch (error)
         {
+            console.error("Error initializing graph:", error);
             this.ERROR = true;
         }
     }
@@ -81,14 +85,13 @@ export class Graph {
                 type,
                 location,
             );
-
             this._nodes.set(packageJSON.name, node);
+            // Add node to graph
+            this.graph.addNode(node);
         }
 
         const node = this._nodes.get(packageJSON.name)!;
-
-        const deparray: Array<"dependencies" | "peerDependencies" | "devDependencies"> = ["dependencies", "peerDependencies"];
-        if (Arguments.has("include-devdependencies")) deparray.push("devDependencies")
+        const deparray = ["dependencies", "peerDependencies", "devDependencies"];
 
         for (const dependencyType of deparray)
         {
@@ -96,13 +99,12 @@ export class Graph {
             {
                 if (!key.startsWith(this.scope)) continue;
 
-                const existingNode = this._nodes.get(key); // ?? this.createNode(scope, );
+                const existingNode = this._nodes.get(key);
                 if (existingNode)
                 {
-                    node.parents.push(existingNode);
-                    existingNode.children.push(node as PackageNode<LocalPackage>);
-                }
-                else if (leftovers)
+                    // Add edge: dependency (key) → dependent (node)
+                    this.graph.addEdge(key, node.name, dependencyType);
+                } else if (leftovers)
                 {
                     if (leftovers.has(key)) leftovers.get(key)?.push(node.name);
                     else leftovers.set(key, [node.name]);
@@ -113,42 +115,120 @@ export class Graph {
         return node;
     }
 
-    public getOrder(packages: PackageNode<LocalPackage>[]) {
-        const map = new Map<string, string[]>();
-        const batches: PackageNode[][] = [];
+    // In your Graph class
+    public getOrder(
+        packages: PackageNode<LocalPackage>[],
+        sortFilter: string[] = ["dependencies", "peerDependencies"],      // Used for topological sorting
+        includeFilter: string[] = ["devDependencies"]   // Used for which nodes to include
+    ): PackageNode[][] {
+        // Get all nodes we want to include
+        const allPackageIds = packages.map(p => p.name);
+        const subgraph = this.graph.subgraph(allPackageIds);
 
-        for (const node of packages)
+        // Get sorted order based on sortFilter (production deps only)
+        const order = subgraph.toposort(sortFilter);
+
+        // Convert to batches (same as before)
+        const batches: PackageNode[][] = [];
+        const processed = new Set<string>();
+
+        for (const id of order)
         {
-            if (node.name === this.root.name) continue;
-            map.set(node.name, node.ancestors.map(n => n.name));
+            const node = this.get(id);
+            if (node && !processed.has(id))
+            {
+                const ancestors = subgraph.ancestors(id, sortFilter);
+                const allDepsProcessed = ancestors.every(ancestor => processed.has(ancestor.id));
+
+                if (allDepsProcessed)
+                {
+                    const batch = order.filter(currentId => {
+                        const currentNode = this.get(currentId);
+                        if (!currentNode || processed.has(currentId)) return false;
+                        const currentAncestors = subgraph.ancestors(currentId, sortFilter);
+                        return currentAncestors.every(ancestor => processed.has(ancestor.id));
+                    });
+
+                    if (batch.length > 0)
+                    {
+                        batches.push(batch.map(id => this.get(id)!));
+                        batch.forEach(id => processed.add(id));
+                    }
+                }
+            }
         }
 
-        while (map.size > 0)
+        // If we need to include devDeps that weren't in the sort order
+        if (includeFilter?.includes("devDependencies"))
         {
-            const batch: PackageNode[] = [];
-
-            const sorted = Array.from(map.keys()).map(name => {
-                const deps = map.get(name)!;
-                return { name, count: deps.filter(dep => map.has(dep)).length };
-            }).sort((a, b) => a.count - b.count);
-
-            let current: number | undefined;
-            for (const item of sorted)
+            const allIncluded = new Set(batches.flatMap(b => b.map(n => n.name)));
+            const missing = packages.filter(p => !allIncluded.has(p.name));
+            if (missing.length > 0)
             {
-                if (current === undefined) current = item.count;
-                if (current !== item.count) break;
-
-                map.delete(item.name);
-                batch.push(this.get(item.name)!);
+                batches.push(missing);
             }
-
-            batches.push(batch);
         }
 
         return batches;
     }
+
+    // public getOrder(packages: PackageNode<LocalPackage>[], typeFilter?: string[]): PackageNode[][] {
+    //     // Get the subgraph with only the packages we care about
+    //     const packageIds = packages.map(p => p.name);
+    //     const subgraph = this.graph.subgraph(packageIds);
+
+    //     // Get topological order
+    //     const order = subgraph.toposort(typeFilter);
+
+    //     // Convert back to batches (groups of nodes that can be built in parallel)
+    //     const batches: PackageNode[][] = [];
+    //     const processed = new Set<string>();
+
+    //     // Process nodes in topological order, batching those with no unprocessed dependencies
+    //     for (const id of order)
+    //     {
+    //         const node = this.get(id);
+    //         if (node && !processed.has(id))
+    //         {
+    //             // Check if all dependencies of this node are already processed
+    //             const ancestors = subgraph.ancestors(id, typeFilter);
+    //             const allDepsProcessed = ancestors.every(ancestor => processed.has(ancestor.id));
+
+    //             if (allDepsProcessed)
+    //             {
+    //                 // Find all nodes at this level (no unprocessed dependencies)
+    //                 const batch = order.filter(currentId => {
+    //                     const currentNode = this.get(currentId);
+    //                     if (!currentNode || processed.has(currentId)) return false;
+
+    //                     const currentAncestors = subgraph.ancestors(currentId, typeFilter);
+    //                     return currentAncestors.every(ancestor => processed.has(ancestor.id));
+    //                 });
+
+    //                 if (batch.length > 0)
+    //                 {
+    //                     batches.push(batch.map(id => this.get(id)!));
+    //                     batch.forEach(id => processed.add(id));
+    //                 }
+    //             }
+    //         }
+    //     }
+
+    //     return batches;
+    // }
+
+    public getDescendants(name: string, typeFilter?: string[]): PackageNode[] {
+        const descendants = this.graph.descendants(name, typeFilter);
+        return descendants.map(node => this.get(node.id)!);
+    }
+
+    public getAncestors(name: string, typeFilter?: string[]): PackageNode[] {
+        const ancestors = this.graph.ancestors(name, typeFilter);
+        return ancestors.map(node => this.get(node.id)!);
+    }
 }
 
+// PackageGraph remains the same
 export class PackageGraph {
     private static instance = new Graph();
     static initialize() { this.instance = new Graph() }
@@ -159,26 +239,32 @@ export class PackageGraph {
     static get nodes() { return this.instance.nodes }
     static get size() { return this.instance.nodes.length }
     static search(location: string, compare: "start" | "end" = "end") { return this.instance.search(location, compare) }
-    static getOrder(packages: PackageNode<LocalPackage>[]) { return this.instance.getOrder(packages) }
+    static getOrder(packages: PackageNode<LocalPackage>[], typeFilter?: string[]) {
+        return this.instance.getOrder(packages, typeFilter)
+    }
+    static getDescendants(name: string, typeFilter?: string[]) {
+        return this.instance.getDescendants(name, typeFilter)
+    }
+    static getAncestors(name: string, typeFilter?: string[]) {
+        return this.instance.getAncestors(name, typeFilter)
+    }
 }
 
-// helper functions 
+// Helper functions remain the same...
 function findWorkspaceRoot(startDir: string): string {
     if (process.env.npm_config_local_prefix && isRoot(process.env.npm_config_local_prefix)) return process.env.npm_config_local_prefix;
 
     let dir = startDir;
     while (dir !== path.dirname(dir))
-    { // stop at filesystem root
-        if (isRoot(dir)) return dir; // found monorepo root
-
+    {
+        if (isRoot(dir)) return dir;
         dir = path.dirname(dir);
     }
-    return startDir; // fallback
+    return startDir;
 }
 
 function isRoot(dir: string) {
     if (!fs.existsSync(path.join(dir, "package.json"))) return false;
-
     const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf-8"));
     return !!pkg.workspaces;
 }

--- a/packages/runtime/cli/information/src/information.ts
+++ b/packages/runtime/cli/information/src/information.ts
@@ -42,24 +42,34 @@ export class Information {
     static get outFolder() { return this.package.outFolder }
 
     static getBatches(args = Arguments.instance) {
+        // Determine which edge types to include
+        const typeFilter = args.get("type-filter") ?? ["dependencies", "peerDependencies", "devDependencies"];
+
         if (!args.has("individual") && (args.has("all") || Information.package.name === Information.root.name))
         {
-            return PackageGraph.getOrder(PackageGraph.nodes)
+            return PackageGraph.getOrder(PackageGraph.nodes.filter(n => n.type !== "root"), typeFilter);
         }
 
         if (!args.has("individual") && args.has("bloodline"))
         {
-            return PackageGraph.getOrder(Information.package.ancestors.concat(Information.package, ...Information.package.descendants));
+            const ancestors = PackageGraph.getAncestors(Information.package.name, typeFilter);
+            const descendants = PackageGraph.getDescendants(Information.package.name, typeFilter);
+            const nodes = [...ancestors, Information.package, ...descendants];
+            return PackageGraph.getOrder(nodes, typeFilter);
         }
 
         if (!args.has("individual") && args.has("descendants"))
         {
-            return PackageGraph.getOrder(Information.package.descendants.concat(Information.package));
+            const descendants = PackageGraph.getDescendants(Information.package.name, typeFilter);
+            const nodes = [...descendants, Information.package];
+            return PackageGraph.getOrder(nodes, typeFilter);
         }
 
         if (!args.has("individual") && args.has("ancestors"))
         {
-            return PackageGraph.getOrder(Information.package.ancestors.concat(Information.package));
+            const ancestors = PackageGraph.getAncestors(Information.package.name, typeFilter);
+            const nodes = [...ancestors, Information.package];
+            return PackageGraph.getOrder(nodes, typeFilter);
         }
 
         // individual 

--- a/packages/runtime/cli/information/src/node.ts
+++ b/packages/runtime/cli/information/src/node.ts
@@ -7,16 +7,16 @@ import { getEntryPoints, getExternals, getTSconfig, getTSlocation, outFolder, so
 import { Remote } from "./remote";
 import type { LocalPackage, RootPackage } from "./types";
 import { Cache } from "./cache";
+import { GraphNode } from "@papit/data-structure";
 
-export class PackageNode<T extends LocalPackage | RootPackage = LocalPackage> {
-    parents: PackageNode<LocalPackage>[] = [];
-    children: PackageNode<LocalPackage>[] = [];
-
+export class PackageNode<T extends LocalPackage | RootPackage = LocalPackage> extends GraphNode {
     constructor(
         private _packageJSON: T,
         private _type: "external" | "root" | "local",
         private _location: string,
-    ) { }
+    ) {
+        super(_packageJSON.name);
+    }
 
     get packageJSON() { return this._packageJSON }
     get type() { return this._type }
@@ -101,44 +101,5 @@ export class PackageNode<T extends LocalPackage | RootPackage = LocalPackage> {
         }
 
         return this._tsconfig;
-    }
-
-    get descendants() {
-        const output: PackageNode[] = [];
-        const visited = new Set<PackageNode>();
-        const stack = [...this.children];
-
-        while (stack.length)
-        {
-            const node = stack.pop()!;
-            if (visited.has(node)) continue;
-
-            visited.add(node);
-            output.push(node);
-            stack.push(...node.children);
-        }
-
-        return output;
-    }
-    get ancestors() {
-        const output: PackageNode[] = [];
-        const visited = new Set<PackageNode>();
-        const stack = [...this.parents];
-
-        while (stack.length)
-        {
-            const node = stack.pop()!;
-            if (visited.has(node)) 
-            {
-                // need to push higher up for dependency order 
-                continue;
-            }
-
-            visited.add(node);
-            output.push(node);
-            stack.push(...node.parents);
-        }
-
-        return output;
     }
 }

--- a/packages/runtime/cli/server/package.json
+++ b/packages/runtime/cli/server/package.json
@@ -1,101 +1,101 @@
 {
-    "name": "@papit/server",
-    "description": "a simple but powerful dev server that can locate locale assets and package and even dependency assets",
-    "keywords": [
-        "papit",
-        "node",
-        "typescript",
-        "dev-server"
-    ],
-    "version": "1.0.5",
-    "scripts": {
-        "build": "npx @papit/build -- --error --ancestors",
-        "watch": "tsc -w",
-        "start": "npx @papit/build -- --no-install --info --live --execute ./lib/bundle.js",
-        "test": "node --test tests/**/*.test.js",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit -- --component",
-        "generate-explorer-icons": "npx @papit/svg-spritesheet --input ./explorer-icons --output ./asset/icons/explorer-spritesheet.svg"
-    },
-    "bin": {
-        "papit-server": "lib/bin.js"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/network/dev-server",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/network/dev-server"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/arguments": "0.0.1",
-        "@papit/build": "0.0.5",
-        "@papit/bundle-js": "0.0.2",
-        "@papit/deep-merge": "0.0.1",
-        "@papit/html": "0.0.1",
-        "@papit/information": "0.0.6",
-        "@papit/terminal": "0.0.2",
-        "chokidar": "^5.0.0",
-        "esbuild": "0.27.2"
-    },
-    "devDependencies": {
-        "@types/node": "22.10.2",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "priority": 5,
-        "type": "node",
-        "main": "server",
-        "components": {
-            "socket": {
-                "className": "Socket"
-            },
-            "request": {
-                "className": "Request"
-            },
-            "server": {
-                "className": "Server"
-            },
-            "translation": {
-                "className": "Translation"
-            },
-            "util": {
-                "className": "Util"
-            }
-        }
-    },
-    "remoteVersion": "1.0.5"
+  "name": "@papit/server",
+  "description": "a simple but powerful dev server that can locate locale assets and package and even dependency assets",
+  "keywords": [
+    "papit",
+    "node",
+    "typescript",
+    "dev-server"
+  ],
+  "version": "1.0.6",
+  "scripts": {
+    "build": "npx @papit/build -- --error --ancestors",
+    "watch": "tsc -w",
+    "start": "npx @papit/build -- --no-install --info --live --execute ./lib/bundle.js",
+    "test": "node --test tests/**/*.test.js",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit -- --component",
+    "generate-explorer-icons": "npx @papit/svg-spritesheet --input ./explorer-icons --output ./asset/icons/explorer-spritesheet.svg"
+  },
+  "bin": {
+    "papit-server": "lib/bin.js"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/network/dev-server",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/network/dev-server"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/arguments": "0.0.1",
+    "@papit/build": "0.0.6",
+    "@papit/bundle-js": "0.0.2",
+    "@papit/deep-merge": "0.0.1",
+    "@papit/html": "0.0.1",
+    "@papit/information": "0.0.7",
+    "@papit/terminal": "0.0.2",
+    "chokidar": "^5.0.0",
+    "esbuild": "0.27.2"
+  },
+  "devDependencies": {
+    "@types/node": "22.10.2",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "priority": 5,
+    "type": "node",
+    "main": "server",
+    "components": {
+      "socket": {
+        "className": "Socket"
+      },
+      "request": {
+        "className": "Request"
+      },
+      "server": {
+        "className": "Server"
+      },
+      "translation": {
+        "className": "Translation"
+      },
+      "util": {
+        "className": "Util"
+      }
+    }
+  },
+  "remoteVersion": "1.0.5"
 }

--- a/packages/runtime/cli/server/src/components/http/socket.ts
+++ b/packages/runtime/cli/server/src/components/http/socket.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import { Arguments } from "@papit/arguments";
 import { Terminal } from "@papit/terminal";
-import { Information, PackageNode } from "@papit/information";
+import { Information, PackageGraph, PackageNode } from "@papit/information";
 import { getPACKAGE } from "./url";
 
 const connectedClients = new Map<Duplex, PackageNode>();
@@ -105,7 +105,8 @@ export function update(node: PackageNode) {
         connectedClients.forEach((socketNode, socket) => {
             if (socketNode.name !== node.name)
             {
-                if (!node?.descendants.some(n => n.name === socketNode.name)) return;
+                const descendants = PackageGraph.getDescendants(node.name);
+                if (!descendants.some(n => n.name === socketNode.name)) return;
             }
 
             if (!socket || !socket.writable)

--- a/packages/runtime/cli/server/src/index.ts
+++ b/packages/runtime/cli/server/src/index.ts
@@ -14,8 +14,7 @@ export * from "components/http"
 
 export async function setup() {
 
-    Arguments.set("include-devdependencies", true);
-    PackageGraph.initialize();
+    // PackageGraph.initialize();
     const serverPackageLocation = getPackageLocationFromImportMeta(import.meta.url);
 
     if (serverPackageLocation == null)

--- a/packages/runtime/cli/version/package.json
+++ b/packages/runtime/cli/version/package.json
@@ -1,80 +1,80 @@
 {
-    "name": "@papit/version",
-    "description": "monorepo version flood helper, making sure descendants get patched",
-    "keywords": [
-        "papit",
-        "node",
-        "typescript",
-        "version"
-    ],
-    "version": "0.0.5",
-    "scripts": {
-        "build": "npx @papit/build -- --error --ancestors",
-        "watch": "tsc -w",
-        "start": "npm run build -- --dev && node ./lib/bundle.js",
-        "test": "node --test tests/**/*.test.js",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit -- --component"
+  "name": "@papit/version",
+  "description": "monorepo version flood helper, making sure descendants get patched",
+  "keywords": [
+    "papit",
+    "node",
+    "typescript",
+    "version"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build -- --error --ancestors",
+    "watch": "tsc -w",
+    "start": "npm run build -- --dev && node ./lib/bundle.js",
+    "test": "node --test tests/**/*.test.js",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit -- --component"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "bin": {
+    "papit-version": "lib/bundle.js"
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/version",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/runtime/cli/version"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/arguments": "0.0.1",
+    "@papit/information": "0.0.7",
+    "@papit/terminal": "0.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "22.10.2",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "node",
+    "main": {
+      "name": "version",
+      "className": "Version"
     },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "bin": {
-        "papit-version": "lib/bundle.js"
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/runtime/cli/version",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/runtime/cli/version"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/arguments": "0.0.1",
-        "@papit/information": "0.0.6",
-        "@papit/terminal": "0.0.2"
-    },
-    "devDependencies": {
-        "@types/node": "22.10.2",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "node",
-        "main": {
-            "name": "version",
-            "className": "Version"
-        },
-        "components": {}
-    },
-    "remoteVersion": "0.0.5"
+    "components": {}
+  },
+  "remoteVersion": "0.0.5"
 }

--- a/packages/runtime/cli/version/src/components/post.ts
+++ b/packages/runtime/cli/version/src/components/post.ts
@@ -76,8 +76,8 @@ function runner(node: PackageNode, updateDependencies: Map<string, string>) {
         {
             if (node.packageJSON.dependencies?.[name] && node.packageJSON.dependencies[name] !== version)
             {
+                if (node.packageJSON.dependencies[name] !== "*") changed = true;
                 node.packageJSON.dependencies[name] = version;
-                changed = true;
             }
             if (node.packageJSON.devDependencies?.[name] && node.packageJSON.devDependencies[name] !== version)
             {

--- a/packages/web/design-system/1-foundations/button/package.json
+++ b/packages/web/design-system/1-foundations/button/package.json
@@ -1,85 +1,85 @@
 {
-    "name": "@papit/button",
-    "description": "basic button with minimal style",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "button"
-    ],
-    "version": "0.1.2",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/1-foundations/button",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/1-foundations/button"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "*",
-        "@papit/codeblock": "0.1.6"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "button",
-        "htmlprefix": "pap",
-        "components": {
-            "button": {
-                "className": "Button",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.1.2"
+  "name": "@papit/button",
+  "description": "basic button with minimal style",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "button"
+  ],
+  "version": "0.1.2",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/1-foundations/button",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/1-foundations/button"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "*",
+    "@papit/codeblock": "0.1.7"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "button",
+    "htmlprefix": "pap",
+    "components": {
+      "button": {
+        "className": "Button",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.1.2"
 }

--- a/packages/web/design-system/1-foundations/field/package.json
+++ b/packages/web/design-system/1-foundations/field/package.json
@@ -1,84 +1,85 @@
 {
-    "name": "@papit/field",
-    "description": "a extendable class for form elements to deal with basics like error and warnings ",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "field"
-    ],
-    "version": "0.0.1",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "git+https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/1-foundations/field",
-    "bugs": {
-        "url": "git+https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/1-foundations/field"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "*"
-    },
-    "devDependencies": {
-        "@papit/codeblock": "*",
-        "@papit/theme": "*",
-        "@papit/translator": "^0.1.0",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "field",
-        "htmlprefix": "pap",
-        "components": {
-            "field": {
-                "className": "Field",
-                "htmlprefix": "pap"
-            }
-        }
+  "name": "@papit/field",
+  "description": "a extendable class for form elements to deal with basics like error and warnings ",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "field"
+  ],
+  "version": "0.1.0",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
     }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "git+https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/1-foundations/field",
+  "bugs": {
+    "url": "git+https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/1-foundations/field"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/codeblock": "0.1.7",
+    "@papit/theme": "*",
+    "@papit/translator": "^0.1.0",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "field",
+    "htmlprefix": "pap",
+    "components": {
+      "field": {
+        "className": "Field",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.1.0"
 }

--- a/packages/web/design-system/1-foundations/field/src/component.ts
+++ b/packages/web/design-system/1-foundations/field/src/component.ts
@@ -101,6 +101,7 @@ export class Field extends CustomElementInternals {
         if (this._target)
         {
             // cleanup 
+            this._target.removeEventListener("input", this.handlechange);
             this._target.removeEventListener("change", this.handlechange);
             this._target.removeEventListener("invalid", this.handleinvalid);
         }
@@ -109,6 +110,7 @@ export class Field extends CustomElementInternals {
 
         if (!value) return;
 
+        value.addEventListener("input", this.handlechange);
         value.addEventListener("change", this.handlechange);
         value.addEventListener("invalid", this.handleinvalid);
     }
@@ -215,25 +217,25 @@ export class Field extends CustomElementInternals {
 
             // field-specific translation
             const specific = this.t(`fields.${fieldName}.${mapref}.${customKey}`);
-            if (specific) return specific;
+            if (specific && specific !== `fields.${fieldName}.${mapref}.${customKey}`) return specific;
 
             // global translation
             const global = this.t(`fields.global.${customKey}`);
-            if (global) return global;
+            if (global && global !== `fields.global.${customKey}`) return global;
 
             return customKey;
         }
 
         // 3. Field-specific translation (e.g. fields.email.error.tooShort)
         const specific = this.t(`fields.${fieldName}.${mapref}.${key}`);
-        if (specific) return specific;
+        if (specific && specific !== `fields.${fieldName}.${mapref}.${key}`) return specific;
 
         // 4. Global translation (e.g. fields.global.tooShort)
         const global = this.t(`fields.global.${key}`);
-        if (global) return global;
+        if (global && global !== `fields.global.${key}`) return global;
 
         // 5. Fallback
-        return "";
+        return key;
     }
 
     private isTarget(element: Element | null): element is HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement {
@@ -242,25 +244,26 @@ export class Field extends CustomElementInternals {
     }
 
     protected renderStates() {
-        const errorEntries = Object.entries(this.errorState);
-        const warningEntries = Object.entries(this.warningState);
+        const errorEntries = Object.entries(this.errorState).flatMap(([key, msg]) => msg.map((m, index) => m));
+        const warningEntries = Object.entries(this.warningState).flatMap(([key, msg]) => msg.map((m, index) => m));
 
         if (!errorEntries.length && !warningEntries.length) return null;
+
 
         return html`
             <div part="states">
                 ${errorEntries.length ? html`
                     <ul part="errors">
-                        ${errorEntries.map(([key, msg]) => msg.map((m, index) => html`
-                            <li part="error" data-key="${key}-${index}">${m}</li>
-                        `))}
+                        ${errorEntries.map(value => html`
+                            <li part="error">${value}</li>
+                        `)}
                     </ul>
                 ` : null}
                 ${warningEntries.length ? html`
                     <ul part="warnings">
-                        ${warningEntries.map(([key, msg]) => msg.map((m, index) => html`
-                            <li part="warning" data-key="${key}-${index}">${m}</li>
-                        `))}
+                        ${warningEntries.map(value => html`
+                            <li part="warning">${value}</li>
+                        `)}
                     </ul>
                 ` : null}
             </div>

--- a/packages/web/design-system/1-foundations/group/package.json
+++ b/packages/web/design-system/1-foundations/group/package.json
@@ -1,85 +1,85 @@
 {
-    "name": "@papit/group",
-    "description": "A structural, non-visual component that manages keyboard navigation within a set of child elements using roving tabindex",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "group"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/foundations/group",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/foundations/group"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "group",
-        "htmlprefix": "pap",
-        "components": {
-            "group": {
-                "className": "Group",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/group",
+  "description": "A structural, non-visual component that manages keyboard navigation within a set of child elements using roving tabindex",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "group"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/foundations/group",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/foundations/group"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "group",
+    "htmlprefix": "pap",
+    "components": {
+      "group": {
+        "className": "Group",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/web/design-system/1-foundations/icon/package.json
+++ b/packages/web/design-system/1-foundations/icon/package.json
@@ -1,85 +1,85 @@
 {
-    "name": "@papit/icon",
-    "description": "Renders SVG icons either by referencing a <symbol> in an existing spritesheet or by fetching an SVG from a URL. If the spritesheet is not yet present in the DOM, it fetches the SVG and injects it into the document body for reuse via symbol references.",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "icon"
-    ],
-    "version": "0.1.5",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/foundations/icon",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/foundations/icon"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "icon",
-        "htmlprefix": "pap",
-        "components": {
-            "icon": {
-                "className": "Icon",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.1.5"
+  "name": "@papit/icon",
+  "description": "Renders SVG icons either by referencing a <symbol> in an existing spritesheet or by fetching an SVG from a URL. If the spritesheet is not yet present in the DOM, it fetches the SVG and injects it into the document body for reuse via symbol references.",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "icon"
+  ],
+  "version": "0.1.5",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/foundations/icon",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/foundations/icon"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "icon",
+    "htmlprefix": "pap",
+    "components": {
+      "icon": {
+        "className": "Icon",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.1.5"
 }

--- a/packages/web/design-system/1-foundations/placement/package.json
+++ b/packages/web/design-system/1-foundations/placement/package.json
@@ -1,85 +1,85 @@
 {
-    "name": "@papit/placement",
-    "description": "A small helper component that uses the @position-try to place an anchor to fit the best view based on the placement attribute/property ",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "placement"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/foundations/placement",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/foundations/placement"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "placement",
-        "htmlprefix": "pap",
-        "components": {
-            "placement": {
-                "className": "Placement",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/placement",
+  "description": "A small helper component that uses the @position-try to place an anchor to fit the best view based on the placement attribute/property ",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "placement"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/foundations/placement",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/foundations/placement"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "placement",
+    "htmlprefix": "pap",
+    "components": {
+      "placement": {
+        "className": "Placement",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/web/design-system/1-foundations/treeview/package.json
+++ b/packages/web/design-system/1-foundations/treeview/package.json
@@ -1,86 +1,86 @@
 {
-    "name": "@papit/treeview",
-    "description": "A logical component that deals with tree view, uses the details + summary elements to deal with open and closing sub elements ",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "treeview"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/1-foundations/treeview",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/1-foundations/treeview"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/icon": "0.1.5",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/codeblock": "0.1.6",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "treeview",
-        "htmlprefix": "pap",
-        "components": {
-            "treeview": {
-                "className": "Treeview",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/treeview",
+  "description": "A logical component that deals with tree view, uses the details + summary elements to deal with open and closing sub elements ",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "treeview"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/1-foundations/treeview",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/1-foundations/treeview"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/icon": "0.1.5",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/codeblock": "0.1.7",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "treeview",
+    "htmlprefix": "pap",
+    "components": {
+      "treeview": {
+        "className": "Treeview",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/web/design-system/atoms/accordion/package.json
+++ b/packages/web/design-system/atoms/accordion/package.json
@@ -1,88 +1,88 @@
 {
-    "name": "@papit/accordion",
-    "description": "a wcag complient accordion component ",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "accordion"
-    ],
-    "version": "0.1.4",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/accordion",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/accordion"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/button": "0.1.2",
-        "@papit/group": "0.0.6",
-        "@papit/icon": "0.1.5",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/codeblock": "0.1.6",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "accordion",
-        "htmlprefix": "pap",
-        "components": {
-            "accordion": {
-                "className": "Accordion",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.1.4"
+  "name": "@papit/accordion",
+  "description": "a wcag complient accordion component ",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "accordion"
+  ],
+  "version": "0.1.4",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/accordion",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/accordion"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/button": "0.1.2",
+    "@papit/group": "0.0.6",
+    "@papit/icon": "0.1.5",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/codeblock": "0.1.7",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "accordion",
+    "htmlprefix": "pap",
+    "components": {
+      "accordion": {
+        "className": "Accordion",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.1.4"
 }

--- a/packages/web/design-system/atoms/carousel/package.json
+++ b/packages/web/design-system/atoms/carousel/package.json
@@ -1,88 +1,88 @@
 {
-    "name": "@papit/carousel",
-    "description": "a simple swipable carousel component complient with the WCAG pattern",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "carousel"
-    ],
-    "version": "0.0.2",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/carousel",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/carousel"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/button": "0.1.2",
-        "@papit/group": "0.0.6",
-        "@papit/icon": "0.1.5",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/codeblock": "0.1.6",
-        "@papit/theme": "*",
-        "@papit/translator": "^0.1.0",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "carousel",
-        "htmlprefix": "pap",
-        "components": {
-            "carousel": {
-                "className": "Carousel",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.2"
+  "name": "@papit/carousel",
+  "description": "a simple swipable carousel component complient with the WCAG pattern",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "carousel"
+  ],
+  "version": "0.0.2",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/carousel",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/carousel"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/button": "0.1.2",
+    "@papit/group": "0.0.6",
+    "@papit/icon": "0.1.5",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/codeblock": "0.1.7",
+    "@papit/theme": "*",
+    "@papit/translator": "^0.1.0",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "carousel",
+    "htmlprefix": "pap",
+    "components": {
+      "carousel": {
+        "className": "Carousel",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.2"
 }

--- a/packages/web/design-system/atoms/dialog/README.md
+++ b/packages/web/design-system/atoms/dialog/README.md
@@ -111,20 +111,22 @@ The footer area is hidden (zero padding) when no content is slotted into it, so 
 
 ### Attributes / Properties
 
-| Name                  | Type      | Default | Description                                                             |
-| --------------------- | --------- | ------- | ----------------------------------------------------------------------- |
-| `header`              | `string`  | —       | Text rendered as `<h1>` in the header. Overridden by the `header` slot. |
-| `open`                | `boolean` | `false` | Reflects the open state of the underlying `<dialog>`.                   |
-| `close-outside-click` | `boolean` | `false` | When set, clicking outside the dialog (on the backdrop) closes it.      |
+| Name                  | Type      | Default | Description                                                                  |
+| --------------------- | --------- | ------- | ---------------------------------------------------------------------------- |
+| `header`              | `string`  | —       | Text rendered as `<h1>` in the header. Overridden by the `header` slot.      |
+| `open`                | `boolean` | `false` | Reflects the open state of the underlying `<dialog>`.                        |
+| `close-outside-click` | `boolean` | `false` | When set to `true`, clicking outside the dialog (on the backdrop) closes it. |
+| `modal`               | `boolean` | `true`  | Determines if `toggle()` uses `showModal()` (`true`) or `show()` (`false`).  |
 
 ### Methods
 
-| Method          | Description                              |
-| --------------- | ---------------------------------------- |
-| `show()`        | Opens as a non-modal dialog.             |
-| `showModal()`   | Opens as a modal dialog with a backdrop. |
-| `showPopover()` | Opens via the Popover API. (NOT TESTED)  |
-| `close()`       | Closes the dialog.                       |
+| Method          | Description                                                               |
+| --------------- | ------------------------------------------------------------------------- |
+| `show()`        | Opens as a non-modal dialog.                                              |
+| `showModal()`   | Opens as a modal dialog with a backdrop.                                  |
+| `showPopover()` | Opens via the Popover API. (NOT TESTED)                                   |
+| `close()`       | Closes the dialog.                                                        |
+| `toggle()`      | Toggles between open and closed. Uses `modal` property to determine mode. |
 
 ### Slots
 
@@ -147,11 +149,12 @@ The footer area is hidden (zero padding) when no content is slotted into it, so 
 
 The component integrates with the native `command` / `commandfor` attribute pattern:
 
-| `command` value | Effect                         |
-| --------------- | ------------------------------ |
-| `show-modal`    | Opens the dialog as a modal.   |
-| `show`          | Opens the dialog as non-modal. |
-| `close`         | Closes the dialog.             |
+| `command` value | Effect                                                            |
+| --------------- | ----------------------------------------------------------------- |
+| `show-modal`    | Opens the dialog as a modal.                                      |
+| `show`          | Opens the dialog as non-modal.                                    |
+| `toggle`        | Toggles the dialog. Uses the `modal` attribute to determine mode. |
+| `close`         | Closes the dialog.                                                |
 
 The component also responds to `popovertarget` to open via the Popover API.
 
@@ -161,9 +164,12 @@ The component also responds to `popovertarget` to open via the Popover API.
 
 `pap-dialog` follows the [WAI-ARIA Dialog (Modal) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/):
 
-- The host element carries `role="dialog"`.
-- The built-in close button receives `autofocus` when the dialog opens, keeping focus inside the modal.
-- `showModal()` traps focus within the dialog and blocks interaction with inert background content, matching the native `<dialog>` behaviour.
+- The native `<dialog>` element provides implicit `role="dialog"` for proper semantics.
+- The `aria-modal` attribute is automatically set to `true` when using `showModal()`.
+- When opened as a modal (`showModal()`), focus is automatically managed:
+  - Focus moves to the built-in close button for immediate keyboard access
+  - This predictable behavior helps users understand how to close the dialog
+  - Users can also press the `Escape` key to close, as provided by the native `<dialog>`
 - The backdrop provides a visual overlay; combine with `close-outside-click` for pointer-driven dismissal.
 
 ---

--- a/packages/web/design-system/atoms/dialog/package.json
+++ b/packages/web/design-system/atoms/dialog/package.json
@@ -1,86 +1,86 @@
 {
-    "name": "@papit/dialog",
-    "description": "A simple, accessible wrapper around the native <dialog> element with slot composition, a built-in close button, and support for modal, non-modal, and popover display modes.",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "dialog"
-    ],
-    "version": "0.0.7",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/dialog",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/dialog"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/icon": "0.1.5",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "dialog",
-        "htmlprefix": "pap",
-        "components": {
-            "dialog": {
-                "className": "Dialog",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.7"
+  "name": "@papit/dialog",
+  "description": "A simple, accessible wrapper around the native <dialog> element with slot composition, a built-in close button, and support for modal, non-modal, and popover display modes.",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "dialog"
+  ],
+  "version": "0.0.8",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/dialog",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/dialog"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/icon": "0.1.5",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "dialog",
+    "htmlprefix": "pap",
+    "components": {
+      "dialog": {
+        "className": "Dialog",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.7"
 }

--- a/packages/web/design-system/atoms/dialog/src/component.ts
+++ b/packages/web/design-system/atoms/dialog/src/component.ts
@@ -9,38 +9,13 @@ import "@papit/icon";
 import sheet from "./style.css" assert { type: "css" };
 
 /**
- * A wrapper around the native `<dialog>` element that adds slot-based composition,
- * a built-in close button, optional backdrop-click dismissal, and imperative API methods.
- * Supports the WAI-ARIA Dialog (Modal) pattern.
+ * Wrapper around native `<dialog>` with slots, close button, and backdrop click support.
  *
- * @element pap-dialog
- *
- * @slot - Default slot — the main body content of the dialog
- * @slot header - Optional header content; overrides the `header` attribute when provided
- * @slot footer - Optional footer content; hidden (zero padding) when empty
- *
- * @attr {string}  header              - Text rendered as an `<h1>` inside the header area.
- *                                       Ignored when the `header` slot is filled.
- * @attr {boolean} open                - Reflects the open state of the underlying `<dialog>`.
- *                                       Set programmatically or via the public methods.
- * @attr {boolean} close-outside-click - When present, clicking the backdrop closes the dialog.
- *
- * @csspart dialog - The native `<dialog>` element
- * @csspart header - The `<header>` bar containing the title area and close button
- * @csspart main   - The `<main>` scrollable content area
- * @csspart footer - The `<footer>` slot container
- *
- * @method show()        - Opens the dialog as a non-modal (maps to `HTMLDialogElement.show()`)
- * @method showModal()   - Opens the dialog as a modal with backdrop (maps to `HTMLDialogElement.showModal()`)
- * @method showPopover() - (NOT TESTED) Opens the dialog via the Popover API (maps to `HTMLDialogElement.showPopover()`)
- * @method close()       - Closes the dialog (maps to `HTMLDialogElement.close()`)
- *
- * @example Basic modal dialog triggered by a button
+ * @example
  * ```html
  * <button commandfor="my-dialog" command="show-modal">Open</button>
- *
- * <pap-dialog id="my-dialog" header="Confirm action">
- *   <p>Are you sure you want to continue?</p>
+ * <pap-dialog id="my-dialog" header="Confirm">
+ *   <p>Are you sure?</p>
  *   <div slot="footer">
  *     <button commandfor="my-dialog" command="close">Cancel</button>
  *     <button>Confirm</button>
@@ -48,52 +23,37 @@ import sheet from "./style.css" assert { type: "css" };
  * </pap-dialog>
  * ```
  *
- * @example Non-modal dialog opened imperatively
- * ```html
- * <pap-dialog id="info-dialog" header="Info">
- *   <p>This is a non-modal dialog.</p>
- * </pap-dialog>
+ * @slot - Main content
+ * @slot header - Replaces header text
+ * @slot footer - Action buttons (hidden when empty)
  *
- * <script type="module">
- *   document.querySelector('#info-dialog').show();
- * </script>
- * ```
+ * @attr {string} header - Dialog title
+ * @attr {boolean} open - Open state
+ * @attr {boolean} close-outside-click - Close on backdrop click
+ * @attr {boolean} modal - Use showModal() in toggle() (default: true)
  *
- * @example Dismiss on backdrop click
- * ```html
- * <pap-dialog header="Click outside to close" close-outside-click>
- *   <p>Dialog content</p>
- * </pap-dialog>
- * ```
+ * @method show() - Open non-modal
+ * @method showModal() - Open modal with backdrop
+ * @method close() - Close dialog
+ * @method toggle() - Toggle based on `modal` attr
  *
- * @example Custom header via slot
- * ```html
- * <pap-dialog>
- *   <div slot="header">
- *     <pap-icon name="warning"></pap-icon>
- *     <strong>Warning</strong>
- *   </div>
- *   <p>Something went wrong.</p>
- * </pap-dialog>
- * ```
- *
+ * @csspart dialog - Native `<dialog>` element
+ * @csspart header - Header bar
+ * @csspart main - Content area
+ * @csspart footer - Footer container
+ * 
  * @see {@link https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/ WAI-ARIA Dialog (Modal) Pattern}
  */
-
 export class Dialog extends CustomElement {
     static sheet = sheet;
 
     @query({
         selector: "dialog",
         load(this: Dialog, element: HTMLDialogElement) {
-            element.addEventListener("click", this.handledialogclick);
-            element.addEventListener("close", this.handlativedialogclose);
+            element.setAttribute("aria-modal", String(this.ismodal));
         }
     }) private dialogElement!: HTMLDialogElement;
-    @property({
-        rerender: true,
-        attribute: "aria-header"
-    }) header?: string;
+    @property({ rerender: true }) header?: string;
     @property({
         type: Boolean,
         after(this: Dialog) {
@@ -105,7 +65,15 @@ export class Dialog extends CustomElement {
             if (this.dialogElement) this.dialogElement.open = this.open;
         }
     }) open: boolean = false;
-    @property({ type: Boolean, attribute: "close-outside-click" }) closeoutsideclick = false;
+    @property({ type: Boolean, attribute: "close-outside-click" }) protected closeoutsideclick = false;
+    @property({
+        attribute: "modal",
+        type: Boolean,
+        after(this: Dialog) {
+            if (!this.dialogElement) return;
+            this.dialogElement.setAttribute("aria-modal", String(this.ismodal));
+        }
+    }) protected ismodal = true;
 
     private refs: Element[] = [];
     private _internalopen = false;
@@ -114,8 +82,6 @@ export class Dialog extends CustomElement {
 
     connectedCallback(): void {
         super.connectedCallback();
-
-        this.setAttribute("role", "dialog");
 
         const root = this.getRootNode();
         this.refs = [];
@@ -148,11 +114,13 @@ export class Dialog extends CustomElement {
         this._internalopen = true;
         this.open = true;
         this.dialogElement.show();
+        this.ismodal = false;
     }
     public showModal() {
         this._internalopen = true;
         this.open = true;
         this.dialogElement.showModal();
+        this.ismodal = true;
     }
 
     /**
@@ -169,9 +137,12 @@ export class Dialog extends CustomElement {
         this.open = false;
         this.dialogElement.close();
     }
+    public toggle() {
+        this.open ? this.close() : (this.ismodal ? this.showModal() : this.show());
+    }
 
     @bind
-    private handleCommandRefClick(e: Event) {
+    protected handleCommandRefClick(e: Event) {
         const { currentTarget } = e;
         if (!(currentTarget instanceof HTMLElement)) return;
 
@@ -184,17 +155,21 @@ export class Dialog extends CustomElement {
         {
             this.show();
         }
+        else if (command === "toggle")
+        {
+            this.toggle();
+        }
         else if (command === "close")
         {
             this.close();
         }
     }
     @bind
-    private handlePopoverRefClick() {
+    protected handlePopoverRefClick() {
         this.showPopover();
     }
     @bind
-    private handleheaderslot(e: Event) {
+    protected handleheaderslot(e: Event) {
         if (!(e.currentTarget instanceof HTMLSlotElement)) return;
 
         if (e.currentTarget.assignedNodes().length > 0) 
@@ -205,7 +180,7 @@ export class Dialog extends CustomElement {
         this.requestUpdate();
     }
     @bind
-    private handlefooterslot(e: Event) {
+    protected handlefooterslot(e: Event) {
         if (!(e.currentTarget instanceof HTMLSlotElement)) return;
 
         if (e.currentTarget.assignedNodes().length > 0) 
@@ -216,7 +191,7 @@ export class Dialog extends CustomElement {
         this.requestUpdate();
     }
     @bind
-    private handledialogclick(e: MouseEvent) {
+    protected handledialogclick(e: MouseEvent) {
         if (!this.closeoutsideclick) return;
         if (!this.open) return;
 
@@ -234,14 +209,19 @@ export class Dialog extends CustomElement {
         }
     }
     @bind
-    private handlativedialogclose() {
+    protected handledialogclose() {
         this._internalopen = true;
         this.open = false;
     }
 
     render() {
         return html`
-            <dialog id="dialog" part="dialog">
+            <dialog 
+                id="dialog" 
+                part="dialog"
+                @click="${this.handledialogclick}"
+                @close="${this.handledialogclose}"
+            >
                 <header part="header">
                     <div>
                         <slot @slotchange="${this.handleheaderslot}" name="header"></slot>

--- a/packages/web/design-system/atoms/dialog/tests/dialog/unit.test.ts
+++ b/packages/web/design-system/atoms/dialog/tests/dialog/unit.test.ts
@@ -328,13 +328,6 @@ test.describe("@papit/dialog unit tests", () => {
     // Accessibility
     // -------------------------------------------------------------------------
 
-    test('host element has role="dialog"', async ({ page }) => {
-        const role = await page.evaluate(() => {
-            return document.querySelector('pap-dialog')?.getAttribute('role');
-        });
-        expect(role).toBe('dialog');
-    });
-
     test('close button has aria-label="close"', async ({ page }) => {
         const label = await page.evaluate(() => {
             const dialog = document.querySelector('pap-dialog')!;

--- a/packages/web/design-system/atoms/file-input/package.json
+++ b/packages/web/design-system/atoms/file-input/package.json
@@ -1,87 +1,87 @@
 {
-    "name": "@papit/file-input",
-    "description": "An elegant solution to file input — fully featured with drag-and-drop, file indicator, upload progress, and form association",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "file-input"
-    ],
-    "version": "0.0.1",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "git+https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/file-input",
-    "bugs": {
-        "url": "git+https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/file-input"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/button": "0.1.2",
-        "@papit/icon": "0.1.5",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/codeblock": "0.1.6",
-        "@papit/theme": "*",
-        "@papit/translator": "^0.1.0",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "file-input",
-        "htmlprefix": "pap",
-        "components": {
-            "file-input": {
-                "className": "FileInput",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.1"
+  "name": "@papit/file-input",
+  "description": "An elegant solution to file input — fully featured with drag-and-drop, file indicator, upload progress, and form association",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "file-input"
+  ],
+  "version": "0.0.1",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "git+https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/file-input",
+  "bugs": {
+    "url": "git+https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/file-input"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/button": "0.1.2",
+    "@papit/icon": "0.1.5",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/codeblock": "0.1.7",
+    "@papit/theme": "*",
+    "@papit/translator": "^0.1.0",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "file-input",
+    "htmlprefix": "pap",
+    "components": {
+      "file-input": {
+        "className": "FileInput",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.1"
 }

--- a/packages/web/design-system/atoms/menu/package.json
+++ b/packages/web/design-system/atoms/menu/package.json
@@ -1,99 +1,99 @@
 {
-    "name": "@papit/menu",
-    "description": "A WCAG complient menu component, the aim for simplicity is key",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "menu"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/menu",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/menu"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/group": "0.0.6",
-        "@papit/placement": "0.0.6",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "menu",
-        "htmlprefix": "pap",
-        "components": {
-            "menu": {
-                "className": "Menu",
-                "htmlprefix": "pap"
-            },
-            "menubar": {
-                "className": "Menubar",
-                "htmlprefix": "pap"
-            },
-            "menuitem": {
-                "className": "Menuitem",
-                "htmlprefix": "pap"
-            },
-            "menubutton": {
-                "className": "Menubutton",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/menu",
+  "description": "A WCAG complient menu component, the aim for simplicity is key",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "menu"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/menu",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/menu"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/group": "0.0.6",
+    "@papit/placement": "0.0.6",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "menu",
+    "htmlprefix": "pap",
+    "components": {
+      "menu": {
+        "className": "Menu",
+        "htmlprefix": "pap"
+      },
+      "menubar": {
+        "className": "Menubar",
+        "htmlprefix": "pap"
+      },
+      "menuitem": {
+        "className": "Menuitem",
+        "htmlprefix": "pap"
+      },
+      "menubutton": {
+        "className": "Menubutton",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/web/design-system/atoms/radio/package.json
+++ b/packages/web/design-system/atoms/radio/package.json
@@ -1,86 +1,86 @@
 {
-    "name": "@papit/radio",
-    "description": "a simple radio that is complient with wcag",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "radio"
-    ],
-    "version": "0.0.3",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/radio",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/radio"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/codeblock": "0.1.6",
-        "@papit/group": "0.0.6",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "radio",
-        "htmlprefix": "pap",
-        "components": {
-            "radio": {
-                "className": "Radio",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.3"
+  "name": "@papit/radio",
+  "description": "a simple radio that is complient with wcag",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "radio"
+  ],
+  "version": "0.0.3",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/radio",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/radio"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/codeblock": "0.1.7",
+    "@papit/group": "0.0.6",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "radio",
+    "htmlprefix": "pap",
+    "components": {
+      "radio": {
+        "className": "Radio",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.3"
 }

--- a/packages/web/design-system/atoms/splitter/package.json
+++ b/packages/web/design-system/atoms/splitter/package.json
@@ -1,85 +1,85 @@
 {
-    "name": "@papit/splitter",
-    "description": "A simple splitter following the window splitter pattern, can be used for both horzontal and vertical modes. ",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "splitter"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/splitter",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/splitter"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "splitter",
-        "htmlprefix": "pap",
-        "components": {
-            "splitter": {
-                "className": "Splitter",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/splitter",
+  "description": "A simple splitter following the window splitter pattern, can be used for both horzontal and vertical modes. ",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "splitter"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/splitter",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/splitter"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "splitter",
+    "htmlprefix": "pap",
+    "components": {
+      "splitter": {
+        "className": "Splitter",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/web/design-system/atoms/switch/package.json
+++ b/packages/web/design-system/atoms/switch/package.json
@@ -1,85 +1,85 @@
 {
-    "name": "@papit/switch",
-    "description": "A binary on/off toggle control that participates in forms just like a checkbox. Prefer it over a checkbox when the semantics of \"on / off\" better describe the intent of the interface — e.g. \"Notifications on\" reads more naturally than \"Notifications checked\".",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "switch"
-    ],
-    "version": "0.1.5",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/switch",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/switch"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3",
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "switch",
-        "htmlprefix": "pap",
-        "components": {
-            "switch": {
-                "className": "Switch",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.1.5"
+  "name": "@papit/switch",
+  "description": "A binary on/off toggle control that participates in forms just like a checkbox. Prefer it over a checkbox when the semantics of \"on / off\" better describe the intent of the interface — e.g. \"Notifications on\" reads more naturally than \"Notifications checked\".",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "switch"
+  ],
+  "version": "0.1.5",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/switch",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/switch"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3",
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "switch",
+    "htmlprefix": "pap",
+    "components": {
+      "switch": {
+        "className": "Switch",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.1.5"
 }

--- a/packages/web/design-system/atoms/tabs/package.json
+++ b/packages/web/design-system/atoms/tabs/package.json
@@ -59,7 +59,7 @@
     "@papit/web-component": "0.0.6"
   },
   "devDependencies": {
-    "@papit/codeblock": "0.1.6",
+    "@papit/codeblock": "0.1.7",
     "@papit/theme": "0.0.2",
     "@papit/translator": "0.1.0",
     "@playwright/test": "1.58.0",

--- a/packages/web/design-system/atoms/tooltip/package.json
+++ b/packages/web/design-system/atoms/tooltip/package.json
@@ -1,86 +1,86 @@
 {
-    "name": "@papit/tooltip",
-    "description": "Elegant and easy to use tooltip covering the required WCAG specs",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "tooltip"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/tooltip",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/atoms/tooltip"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/placement": "0.0.6",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "tooltip",
-        "htmlprefix": "pap",
-        "components": {
-            "tooltip": {
-                "className": "Tooltip",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/tooltip",
+  "description": "Elegant and easy to use tooltip covering the required WCAG specs",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "tooltip"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/tooltip",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/tooltip"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/placement": "0.0.6",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "tooltip",
+    "htmlprefix": "pap",
+    "components": {
+      "tooltip": {
+        "className": "Tooltip",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/web/design-system/molecules/codeblock/package.json
+++ b/packages/web/design-system/molecules/codeblock/package.json
@@ -1,90 +1,90 @@
 {
-    "name": "@papit/codeblock",
-    "description": "A block to highlight and preview code, used for display purposes - uses highlight.js",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "codeblock"
-    ],
-    "version": "0.1.6",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/molecules/codeblock",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/molecules/codeblock"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/data-structure": "0.0.1",
-        "@papit/icon": "0.1.5",
-        "@papit/lexer": "0.0.1",
-        "@papit/splitter": "0.0.6",
-        "@papit/switch": "0.1.5",
-        "@papit/tooltip": "0.0.6",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "codeblock",
-        "htmlprefix": "pap",
-        "components": {
-            "codeblock": {
-                "className": "Codeblock",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.1.6"
+  "name": "@papit/codeblock",
+  "description": "A block to highlight and preview code, used for display purposes - uses highlight.js",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "codeblock"
+  ],
+  "version": "0.1.7",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/molecules/codeblock",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/molecules/codeblock"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/data-structure": "0.0.2",
+    "@papit/icon": "0.1.5",
+    "@papit/lexer": "0.0.1",
+    "@papit/splitter": "0.0.6",
+    "@papit/switch": "0.1.5",
+    "@papit/tooltip": "0.0.6",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "codeblock",
+    "htmlprefix": "pap",
+    "components": {
+      "codeblock": {
+        "className": "Codeblock",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.1.6"
 }

--- a/packages/web/design-system/molecules/codeblock/src/component.ts
+++ b/packages/web/design-system/molecules/codeblock/src/component.ts
@@ -157,13 +157,13 @@ export class Codeblock extends CustomElement {
             <div part="display">
                 <header>
                     <pap-tooltip>
-                        <span>${this.t("Theme Toggle")}</span>
-                        <pap-switch slot="target" @change="${this.handleswitch}"></pap-switch>
+                        <span id="theme-toggle">${this.t("Theme Toggle")}</span>
+                        <pap-switch aria-labelledby="theme-toggle" slot="target" @change="${this.handleswitch}"></pap-switch>
                     </pap-tooltip>
 
                     <pap-tooltip placement="top-right">
-                        <span>${this.t("Copy Code")}</span>
-                        <button slot="target" @click="${this.handlecopy}">
+                        <span id="copy-code">${this.t("Copy Code")}</span>
+                        <button aria-labelledby="copy-code" slot="target" @click="${this.handlecopy}">
                             <pap-icon name="done"></pap-icon>
                             <pap-icon name="copy"></pap-icon>
                         </button>
@@ -178,10 +178,10 @@ export class Codeblock extends CustomElement {
             </div>
 
             <div part="code">
-                <pre><code>${unsafeHTML(this.content)}</code></pre>
+                <pre><code aria-hidden="true">${unsafeHTML(this.content)}</code></pre>
                 <details>
-                    <summary>
-                        <pap-icon name="chevron-down"></pap-icon>
+                    <summary aria-label="${this.t("Expand to see more")}">
+                        <pap-icon aria-hidden="true" name="chevron-down"></pap-icon>
                     </summary>
                 </details>
             </div>

--- a/packages/web/design-system/molecules/drawer/.gitignore
+++ b/packages/web/design-system/molecules/drawer/.gitignore
@@ -1,0 +1,22 @@
+# directories
+node_modules/
+dist/
+lib/
+isolated/
+web/
+.temp/
+.npm/
+
+# test
+test-results/
+test-reports/
+
+# Ignore OS-specific files
+Thumbs.db
+.DS_Store
+
+# Ignore any configuration files that may contain sensitive data
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/packages/web/design-system/molecules/drawer/README.md
+++ b/packages/web/design-system/molecules/drawer/README.md
@@ -1,0 +1,127 @@
+# @papit/drawer
+
+A slide-in drawer panel that can be anchored to any edge of the viewport: `left`, `right`, `top`, or `bottom`. Built on the native `<dialog>` element via `showModal()` for automatic focus-trapping, top-layer rendering, and Escape-key handling out of the box.
+
+![Logo](https://github.com/onkelhoy/papit/blob/main/asset/logo.svg)
+
+---
+
+![Type](https://img.shields.io/badge/Type-atoms-orange)
+[![Tests](https://github.com/onkelhoy/papit/actions/workflows/pull-request.yml/badge.svg)](https://github.com/onkelhoy/papit/actions/workflows/pull-request.yml)
+[![NPM version](https://img.shields.io/npm/v/@papit/drawer.svg?logo=npm)](https://www.npmjs.com/package/@papit/drawer)
+
+---
+
+## Installation
+
+```bash
+npm install @papit/drawer
+```
+
+## Usage
+
+### Declarative — `commandfor` / `command`
+
+Any element with `commandfor="<drawer-id>"` and a `command` attribute acts as a trigger. Supported commands: `toggle`, `show-modal`, `show`, `close`.
+
+```html
+<script type="module" defer>
+  import "@papit/drawer";
+</script>
+
+<button commandfor="my-drawer" command="toggle">Open</button>
+
+<pap-drawer id="my-drawer" placement="right" label="Settings">
+  <p>Drawer content goes here.</p>
+  <button commandfor="my-drawer" command="close">Close</button>
+</pap-drawer>
+```
+
+### Static (fixed positioning)
+
+Use `static` attribute for fixed sidebars that overlay content instead of pushing it:
+
+```html
+<pap-drawer id="sidebar" placement="left" static open>
+  <nav>Sidebar navigation</nav>
+</pap-drawer>
+```
+
+### Imperative
+
+```js
+const drawer = document.querySelector("#my-drawer");
+
+drawer.show();
+drawer.close();
+drawer.toggle();
+```
+
+## API
+
+### Attributes
+
+| Attribute             | Type                                     | Default    | Description                                         |
+| --------------------- | ---------------------------------------- | ---------- | --------------------------------------------------- |
+| `placement`           | `"left" \| "right" \| "top" \| "bottom"` | `"right"`  | Which edge the drawer slides in from                |
+| `open`                | `boolean`                                | `false`    | Reflects the open state                             |
+| `label`               | `string`                                 | `"drawer"` | `aria-label` on the panel — use a descriptive value |
+| `close-outside-click` | `boolean`                                | `true`     | Whether clicking the backdrop closes the drawer     |
+| `static`              | `boolean`                                | `false`    | When true, uses fixed positioning (modal overlay)   |
+
+### Methods
+
+| Method     | Description                                        |
+| ---------- | -------------------------------------------------- |
+| `show()`   | Opens the drawer and traps focus inside            |
+| `close()`  | Closes the drawer and returns focus to the trigger |
+| `toggle()` | Toggles between open and closed                    |
+
+### CSS Parts
+
+| Part    | Description                                                                                                        |
+| ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `panel` | The `<dialog>` element that slides in. The `::backdrop` pseudo-element can be styled via `::part(panel)::backdrop` |
+
+### CSS Custom Properties
+
+| Property        | Default   | Description              |
+| --------------- | --------- | ------------------------ |
+| `--timing`      | `180ms`   | Open/close transition    |
+| `--timing-fast` | `80ms`    | Backdrop fade transition |
+| `--shade-1`     | —         | Panel background color   |
+| `--space-3`     | `0.75rem` | Panel inner padding      |
+
+## Accessibility
+
+- Uses `<dialog>` with `showModal()` — focus is trapped inside the open drawer automatically by the browser
+- Escape key closes the drawer natively
+- Focus returns to the triggering element on close
+- `aria-label` on the panel describes the drawer to screen readers — always set a meaningful `label`
+- Follows the [WAI-ARIA Dialog (Modal) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
+
+## Contributing
+
+Contributions are welcome! Please follow the development guidelines and ensure all tests pass before submitting a pull request.
+
+## License
+
+Licensed under the @Papit License 1.0 — Copyright (c) 2024 Henry Pap (@onkelhoy)
+
+**Key points:**
+
+- ✅ Free to use in commercial projects
+- ✅ Free to modify and distribute
+- ✅ Attribution required
+- ❌ Cannot resell the component itself as a standalone product
+
+See the [LICENSE](https://github.com/onkelhoy/papit/blob/main/LICENSE) file for full details.
+
+## Related Components
+
+- [@papit/web-component](https://github.com/onkelhoy/papit/tree/main/packages/system/core) — Core utilities, decorators, and base component class
+- [@papit/dialog](https://github.com/onkelhoy/papit/tree/main/packages/atoms/dialog) — Full-screen modal dialog using the same command pattern
+
+## Support
+
+For issues, questions, or contributions, please visit the [GitHub repository](https://github.com/onkelhoy/papit).

--- a/packages/web/design-system/molecules/drawer/asset/translations/en.json
+++ b/packages/web/design-system/molecules/drawer/asset/translations/en.json
@@ -1,0 +1,7 @@
+{
+  "meta": {
+    "region": "GB",
+    "language": "en-UK"
+  },
+  "drawer": "drawer"
+}

--- a/packages/web/design-system/molecules/drawer/package.json
+++ b/packages/web/design-system/molecules/drawer/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "@papit/drawer",
+  "description": "a simple drawing that can be shown from either side: left,right,bottom,top ",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "drawer"
+  ],
+  "version": "0.0.1",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/atoms/drawer",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/atoms/drawer"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/dialog": "0.0.8",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/codeblock": "0.1.7",
+    "@papit/theme": "*",
+    "@papit/translator": "*",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "drawer",
+    "htmlprefix": "pap",
+    "components": {
+      "drawer": {
+        "className": "Drawer",
+        "htmlprefix": "pap"
+      }
+    }
+  }
+}

--- a/packages/web/design-system/molecules/drawer/src/component.ts
+++ b/packages/web/design-system/molecules/drawer/src/component.ts
@@ -1,0 +1,76 @@
+// import statements 
+// system 
+import { html, property } from "@papit/web-component";
+
+// atoms 
+import { Dialog } from "@papit/dialog";
+
+// local 
+import sheet from "./style.css" assert { type: "css" };
+
+
+/**
+ * Slide-in drawer panel anchored to any edge. Built on native `<dialog>` with `showModal()`.
+ *
+ * @example
+ * ```html
+ * <button commandfor="my-drawer" command="toggle">Open</button>
+ * <pap-drawer id="my-drawer" placement="right">
+ *   <p>Content</p>
+ *   <button commandfor="my-drawer" command="close">Close</button>
+ * </pap-drawer>
+ * ```
+ *
+ * @slot - Main drawer content
+ *
+ * @attr {string} placement - Edge to slide from: "left"|"right"|"top"|"bottom" (default: "right")
+ * @attr {boolean} open - Open state
+ * @attr {string} label - aria-label for the panel (default: "drawer")
+ * @attr {boolean} close-outside-click - Close on backdrop click (default: true)
+ * @attr {boolean} static - When true, uses fixed positioning (modal overlay)
+ *
+ * @method show() - Opens drawer via showModal()
+ * @method close() - Closes drawer
+ * @method toggle() - Toggles open/closed
+ *
+ * @csspart panel - The `<dialog>` element. Style backdrop via `::part(panel)::backdrop`
+ *
+ * @see {@link https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/ WAI-ARIA Dialog (Modal) Pattern}
+ */
+export class Drawer extends Dialog {
+    static sheet = sheet;
+
+    @property({ rerender: true })
+    placement: "left" | "right" | "top" | "bottom" = "right";
+
+    @property({
+        type: Boolean,
+        after(this: Drawer) {
+            if (!this.static) this.ismodal = false;
+        }
+    }) static = false;
+
+    override closeoutsideclick = true;
+    override ismodal = false;
+
+    render() {
+        return html`
+            <dialog
+                id="dialog"
+                part="panel"
+                @click="${this.handledialogclick}"
+                @close="${this.handledialogclose}"
+            >
+                <div class="wrap">
+                    <slot></slot>
+                </div>
+            </dialog>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "pap-drawer": Drawer;
+    }
+}

--- a/packages/web/design-system/molecules/drawer/src/global-css.d.ts
+++ b/packages/web/design-system/molecules/drawer/src/global-css.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css" {
+    const sheet: CSSStyleSheet;
+    export default sheet;
+}

--- a/packages/web/design-system/molecules/drawer/src/index.ts
+++ b/packages/web/design-system/molecules/drawer/src/index.ts
@@ -1,0 +1,16 @@
+import { Drawer } from './component.js';
+
+// export 
+export * from "./component.js";
+
+// Register the element with the browser
+
+if (!window.customElements)
+{
+    throw new Error('Custom Elements not supported');
+}
+
+if (!window.customElements.get('pap-drawer'))
+{
+    window.customElements.define('pap-drawer', Drawer);
+}

--- a/packages/web/design-system/molecules/drawer/src/style.css
+++ b/packages/web/design-system/molecules/drawer/src/style.css
@@ -1,0 +1,145 @@
+:host {
+    display: contents;
+}
+
+dialog {
+    /* reset UA dialog defaults that fight full-edge spanning */
+    margin: 0;
+    padding: 0;
+    border: none;
+    max-width: none;
+    max-height: none;
+    z-index: 10;
+    position: relative;
+
+    overflow: hidden;
+    background-color: var(--shade-1);
+    box-sizing: border-box;
+
+    transition:
+        width var(--timing, 180ms),
+        height var(--timing, 180ms),
+        overlay var(--timing, 180ms) allow-discrete,
+        display var(--timing, 180ms) allow-discrete;
+
+    .wrap {
+        padding: var(--space-3, 0.75rem);
+        overflow: auto;
+        width: 100%;
+        height: 100%;
+        box-sizing: border-box;
+    }
+
+
+
+    &:backdrop {
+        background: rgb(0 0 0 / 0.3);
+        opacity: 0;
+        transition:
+            opacity var(--timing-fast, 80ms),
+            overlay var(--timing-fast, 80ms) allow-discrete,
+            display var(--timing-fast, 80ms) allow-discrete;
+    }
+
+    &[open] {
+
+        &::backdrop {
+            opacity: 1;
+        }
+    }
+}
+
+:host([static]) {
+    dialog {
+        position: fixed;
+    }
+}
+
+/* ── Horizontal ── */
+
+:host([placement="left"]) dialog,
+:host([placement="right"]) dialog {
+    top: 0;
+    /* use explicit dvh — don't rely on bottom:0, UA max-height fights it */
+    height: 100%;
+    width: 0;
+
+    .wrap {
+        min-width: max-content;
+    }
+}
+
+:host([static][placement="left"]) dialog,
+:host([static][placement="right"]) dialog {
+    height: 100dvh;
+}
+
+:host([placement="right"]) dialog {
+    right: 0;
+    left: auto;
+}
+
+:host([placement="left"]) dialog {
+    left: 0;
+    right: auto;
+}
+
+:host([placement="right"]) dialog[open],
+:host([placement="left"]) dialog[open] {
+    width: calc-size(auto, size);
+}
+
+/* ── Vertical ── */
+
+:host([placement="top"]) dialog,
+:host([placement="bottom"]) dialog {
+    left: 0;
+    /* explicit dvw for same reason */
+    width: 100%;
+    height: 0;
+
+    .wrap {
+        min-height: max-content;
+    }
+}
+
+:host([static][placement="top"]) dialog,
+:host([static][placement="bottom"]) dialog {
+    width: 100dvw;
+}
+
+:host([placement="top"]) dialog {
+    top: 0;
+    bottom: auto;
+}
+
+:host([placement="bottom"]) dialog {
+    bottom: 0;
+    top: auto;
+}
+
+:host([placement="top"]) dialog[open],
+:host([placement="bottom"]) dialog[open] {
+    height: calc-size(auto, size);
+}
+
+:host(:not([static])) {
+    display: inline;
+    background-color: var(--shade-1);
+}
+
+@starting-style {
+    dialog[open]::backdrop {
+        opacity: 0;
+    }
+
+    :host([placement="right"]) dialog[open],
+    :host([placement="left"]) dialog[open] {
+        width: 0;
+    }
+
+    :host([placement="top"]) dialog[open],
+    :host([placement="bottom"]) dialog[open] {
+        height: 0;
+    }
+}

--- a/packages/web/design-system/molecules/drawer/tests/drawer/index.html
+++ b/packages/web/design-system/molecules/drawer/tests/drawer/index.html
@@ -1,0 +1,33 @@
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>drawer test</title>
+
+    <script type="module" defer src="main.js"></script>
+</head>
+
+<body>
+    <!-- Non-modal drawer (pushes content) -->
+    <pap-drawer id="base-target" data-testid="base-target">fallback</pap-drawer>
+
+    <!-- Modal drawer (overlay with backdrop) -->
+    <pap-drawer id="modal-target" data-testid="modal-target" modal>modal drawer</pap-drawer>
+
+    <button id="trigger-right" commandfor="base-target" command="toggle">Toggle right</button>
+    <button id="close-right" commandfor="base-target" command="close">Close right</button>
+
+    <button id="trigger-modal" commandfor="modal-target" command="toggle">Toggle modal</button>
+    <button id="close-modal" commandfor="modal-target" command="close">Close modal</button>
+
+    <pap-drawer id="drawer-left" data-testid="drawer-left" placement="left">left</pap-drawer>
+    <pap-drawer id="drawer-top" data-testid="drawer-top" placement="top">top</pap-drawer>
+    <pap-drawer id="drawer-bottom" data-testid="drawer-bottom" placement="bottom">bottom</pap-drawer>
+
+    <button commandfor="drawer-left" command="show-modal">Open left</button>
+    <button commandfor="drawer-top" command="show-modal">Open top</button>
+    <button commandfor="drawer-bottom" command="show-modal">Open bottom</button>
+</body>
+
+</html>

--- a/packages/web/design-system/molecules/drawer/tests/drawer/main.js
+++ b/packages/web/design-system/molecules/drawer/tests/drawer/main.js
@@ -1,0 +1,1 @@
+import '@papit/drawer';

--- a/packages/web/design-system/molecules/drawer/tests/drawer/public/translations/en.json
+++ b/packages/web/design-system/molecules/drawer/tests/drawer/public/translations/en.json
@@ -1,0 +1,7 @@
+{
+  "meta": {
+    "region": "GB",
+    "language": "en-UK"
+  },
+  "drawer": "drawer"
+}

--- a/packages/web/design-system/molecules/drawer/tests/drawer/snapshot.test.ts
+++ b/packages/web/design-system/molecules/drawer/tests/drawer/snapshot.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+    // Navigate to your test page
+    await page.goto('tests/drawer/');
+});
+
+test.describe.skip("@papit/drawer visual regression", () => {
+    test.skip('default snapshot', async ({ page }) => {
+        await expect(page).toHaveScreenshot();
+    });
+})

--- a/packages/web/design-system/molecules/drawer/tests/drawer/unit.test.ts
+++ b/packages/web/design-system/molecules/drawer/tests/drawer/unit.test.ts
@@ -1,0 +1,190 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('tests/drawer/');
+});
+
+test.describe("@papit/drawer unit tests", () => {
+    test('available in DOM', async ({ page }) => {
+        const component = await page.$('pap-drawer');
+        expect(component).not.toBeNull();
+    });
+
+    test('closed by default', async ({ page }) => {
+        const drawer = page.getByTestId('base-target');
+        await expect(drawer).not.toHaveAttribute('open');
+    });
+
+    test('opens on toggle command', async ({ page }) => {
+        await page.click('#trigger-right');
+        const drawer = page.getByTestId('base-target');
+        await expect(drawer).toHaveAttribute('open');
+    });
+
+    test('closes on close command', async ({ page }) => {
+        await page.click('#trigger-right');
+        await page.waitForTimeout(100);
+        const drawer = page.getByTestId('base-target');
+        await expect(drawer).toHaveAttribute('open');
+
+        await page.click('#close-right');
+        await page.waitForTimeout(100);
+        await expect(drawer).not.toHaveAttribute('open');
+    });
+
+    test('toggle closes an already open drawer', async ({ page }) => {
+        await page.click('#trigger-right');
+        await page.waitForTimeout(100);
+        const drawer = page.getByTestId('base-target');
+        await expect(drawer).toHaveAttribute('open');
+
+        await page.click('#trigger-right');
+        await page.waitForTimeout(100);
+        await expect(drawer).not.toHaveAttribute('open');
+    });
+
+    test('default placement is right', async ({ page }) => {
+        const drawer = page.getByTestId('base-target');
+        await expect(drawer).toHaveAttribute('placement', 'right');
+    });
+
+    test('left placement reflected', async ({ page }) => {
+        const drawer = page.getByTestId('drawer-left');
+        await expect(drawer).toHaveAttribute('placement', 'left');
+    });
+
+    test('top placement reflected', async ({ page }) => {
+        const drawer = page.getByTestId('drawer-top');
+        await expect(drawer).toHaveAttribute('placement', 'top');
+    });
+
+    test('bottom placement reflected', async ({ page }) => {
+        const drawer = page.getByTestId('drawer-bottom');
+        await expect(drawer).toHaveAttribute('placement', 'bottom');
+    });
+
+    test('opens imperatively via show()', async ({ page }) => {
+        await page.evaluate(() => {
+            (document.getElementById('base-target') as any).show();
+        });
+        const drawer = page.getByTestId('base-target');
+        await expect(drawer).toHaveAttribute('open');
+    });
+
+    test('closes imperatively via close()', async ({ page }) => {
+        await page.evaluate(() => {
+            const el = document.getElementById('base-target') as any;
+            el.show();
+            el.close();
+        });
+        const drawer = page.getByTestId('base-target');
+        await expect(drawer).not.toHaveAttribute('open');
+    });
+
+    test('open command opens drawer', async ({ page }) => {
+        // The button now uses command="show-modal"
+        await page.click('button[commandfor="drawer-left"]');
+        await page.waitForTimeout(100);
+        const drawer = page.getByTestId('drawer-left');
+        await expect(drawer).toHaveAttribute('open');
+    });
+
+    // Modal-specific tests using the modal-target drawer
+    test.describe('modal drawer features', () => {
+        test('panel is accessible as dialog role', async ({ page }) => {
+            await page.click('#trigger-modal');
+            await page.waitForTimeout(100);
+
+            // Native dialog has implicit role="dialog", so check the element exists and is a dialog
+            const hasDialogElement = await page.evaluate(() => {
+                const drawer = document.querySelector('[data-testid="modal-target"]');
+                if (drawer && drawer.shadowRoot)
+                {
+                    const dialog = drawer.shadowRoot.querySelector('dialog');
+                    // Check that it's a dialog element (native role is implicit)
+                    return dialog?.tagName === 'DIALOG';
+                }
+                return false;
+            });
+            expect(hasDialogElement).toBe(true);
+        });
+
+        test('panel has aria-modal', async ({ page }) => {
+            await page.click('#trigger-modal');
+            await page.waitForTimeout(100);
+
+            const ariaModal = await page.evaluate(() => {
+                const drawer = document.querySelector('[data-testid="modal-target"]');
+                if (drawer && drawer.shadowRoot)
+                {
+                    const dialog = drawer.shadowRoot.querySelector('dialog');
+                    return dialog?.getAttribute('aria-modal');
+                }
+                return null;
+            });
+            expect(ariaModal).toBe('true');
+        });
+
+        test('closes on Escape key', async ({ page }) => {
+            await page.click('#trigger-modal');
+            await page.waitForTimeout(100);
+            const drawer = page.getByTestId('modal-target');
+            await expect(drawer).toHaveAttribute('open');
+
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(100);
+            await expect(drawer).not.toHaveAttribute('open');
+        });
+
+        test('backdrop click closes drawer', async ({ page }) => {
+            await page.click('#trigger-modal');
+            await page.waitForTimeout(100);
+            const drawer = page.getByTestId('modal-target');
+            await expect(drawer).toHaveAttribute('open');
+
+            // Click on backdrop (top-left corner of viewport)
+            await page.mouse.click(5, 5);
+            await page.waitForTimeout(200);
+            await expect(drawer).not.toHaveAttribute('open');
+        });
+
+        test('close-on-outside-click=false prevents backdrop close', async ({ page }) => {
+            // Set property before opening
+            await page.evaluate(() => {
+                const drawer = document.getElementById('modal-target') as any;
+                drawer.closeoutsideclick = false;
+            });
+
+            await page.click('#trigger-modal');
+            await page.waitForTimeout(100);
+            const drawer = page.getByTestId('modal-target');
+            await expect(drawer).toHaveAttribute('open');
+
+            // Try to click backdrop
+            await page.mouse.click(5, 5);
+            await page.waitForTimeout(200);
+
+            // Drawer should remain open
+            await expect(drawer).toHaveAttribute('open');
+
+            // Reset for other tests
+            await page.evaluate(() => {
+                const drawer = document.getElementById('modal-target') as any;
+                drawer.closeoutsideclick = true;
+            });
+        });
+
+        test('focus returns to trigger after close', async ({ page }) => {
+            const triggerId = 'trigger-modal';
+
+            await page.click(`#${triggerId}`);
+            await page.waitForTimeout(100);
+
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(100);
+
+            const focusedId = await page.evaluate(() => document.activeElement?.id);
+            expect(focusedId).toBe(triggerId);
+        });
+    });
+});

--- a/packages/web/design-system/molecules/drawer/tests/playwright.config.ts
+++ b/packages/web/design-system/molecules/drawer/tests/playwright.config.ts
@@ -1,0 +1,81 @@
+import { Arguments } from "@papit/arguments";
+import { Information, PackageGraph } from "@papit/information";
+import { defineConfig, devices } from '@playwright/test';
+import path from "node:path";
+
+const dirname = path.join(PackageGraph.get("@papit/drawer").location, "tests");
+// const relative = path.relative(Information.root.location, PackageGraph.get("@papit/web-component").location);
+
+export default defineConfig({
+    // Look for test files in the "tests" directory, relative to this configuration file.
+    testDir: dirname,
+
+    // Run all tests in parallel.
+    fullyParallel: true,
+
+    // Fail the build on CI if you accidentally left test.only in the source code.
+    forbidOnly: !!process.env.CI,
+
+    // Retry on CI only.
+    retries: 0,
+
+    // Opt out of parallel tests on CI.
+    workers: !!process.env.CI ? 1 : undefined,
+
+    // reporter, with output path for HTML reports.
+    reporter: [[
+        !!process.env.CI ? "github" : "html",
+        {
+            open: "never",
+            outputFolder: path.join(dirname, "test-reports"),
+        }
+    ]],
+
+    outputDir: path.join(dirname, "test-results"),
+
+    snapshotPathTemplate: '{testDir}/snapshots/{projectName}/{testFilePath}/{arg}-{platform}{ext}',
+
+    use: {
+        // Base URL to use in actions like `await page.goto('/')`.
+        baseURL: process.env.LOCATION ? `http://localhost:3500/${process.env.LOCATION}/` : 'http://localhost:3500/',
+
+        // Collect trace when retrying the failed test.
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+    },
+
+
+    expect: {
+        toHaveScreenshot: {
+            maxDiffPixels: 100,
+            maxDiffPixelRatio: 0.2,
+        },
+    },
+    testIgnore: process.env.SKIP_SNAPSHOTS === "true"
+        ? ["**/snapshot.test.ts"]
+        : [],
+
+    // Configure projects for major browsers.
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+        {
+            name: 'firefox',
+            use: { ...devices['Desktop Firefox'] },
+        },
+        {
+            name: 'webkit',
+            use: { ...devices['Desktop Safari'] },
+        },
+    ],
+    // running web-server before starting tests 
+    webServer: {
+        command: 'npx @papit/server --serve --port=3500 --bundle',
+        url: 'http://localhost:3500',
+        reuseExistingServer: true,
+        stdout: 'pipe',
+        stderr: 'pipe'
+    },
+});

--- a/packages/web/design-system/molecules/drawer/tests/tsconfig.json
+++ b/packages/web/design-system/molecules/drawer/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ".."
+    },
+    "include": [
+        "."
+    ]
+}

--- a/packages/web/design-system/molecules/drawer/tsconfig.json
+++ b/packages/web/design-system/molecules/drawer/tsconfig.json
@@ -1,0 +1,42 @@
+{
+    "compilerOptions": {
+        "target": "es2018",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        // "moduleDetection": "force",
+        "noEmitOnError": true,
+        "skipLibCheck": true,
+        "lib": [
+            "es2020",
+            "dom",
+            "dom.iterable",
+            "esnext"
+        ],
+        "jsx": "react-jsx",
+        "strict": true,
+        "verbatimModuleSyntax": false,
+        "noUncheckedIndexedAccess": false, // use me for strict array/object access checks
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "experimentalDecorators": true,
+        "useDefineForClassFields": false,
+        "outDir": "lib",
+        "rootDir": "src",
+        "declaration": true,
+        "resolveJsonModule": true,
+        "allowJs": true,
+        "baseUrl": "src",
+        "paths": {
+            "@papit/drawer": [
+                "./index"
+            ]
+        },
+        "sourceMap": true,
+        "inlineSources": true,
+        "incremental": true,
+        "tsBuildInfoFile": ".temp/build/tsconfig.tsbuildinfo",
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/packages/web/design-system/molecules/drawer/tsconfig.prod.json
+++ b/packages/web/design-system/molecules/drawer/tsconfig.prod.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "sourceMap": false,
+        "inlineSources": false,
+        "declarationMap": false,
+        "incremental": false
+    }
+}

--- a/packages/web/design-system/molecules/drawer/views/experiment/index.html
+++ b/packages/web/design-system/molecules/drawer/views/experiment/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Drawer | experiment</title>
+
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="style.css" />
+
+    <script defer type="module" src="main.js"></script>
+</head>
+
+<body>
+    <h1>Drawer | experiment</h1>
+    <section>
+        <h2>Example</h2>
+        <pap-codeblock>
+            <pap-drawer static id="drawer-right" aria-label="Right drawer">
+                <p>Right drawer content</p>
+                <button commandfor="drawer-right" command="close">Close</button>
+            </pap-drawer>
+            <pap-drawer static id="drawer-left" placement="left" aria-label="Left drawer">
+                <p>Left drawer content</p>
+                <button commandfor="drawer-left" command="close">Close</button>
+            </pap-drawer>
+            <pap-drawer static id="drawer-top" placement="top" aria-label="Top drawer">
+                <p>Top drawer content</p>
+                <button commandfor="drawer-top" command="close">Close</button>
+            </pap-drawer>
+            <pap-drawer static id="drawer-bottom" placement="bottom" aria-label="Bottom drawer">
+                <p>Bottom drawer content</p>
+                <button commandfor="drawer-bottom" command="close">Close</button>
+            </pap-drawer>
+            <!-- Right (default) -->
+            <button commandfor="drawer-right" command="toggle">Open Right</button>
+
+            <!-- Left -->
+            <button commandfor="drawer-left" command="toggle">Open Left</button>
+
+            <!-- Top -->
+            <button commandfor="drawer-top" command="toggle">Open Top</button>
+
+            <!-- Bottom -->
+            <button commandfor="drawer-bottom" command="toggle">Open Bottom</button>
+        </pap-codeblock>
+    </section>
+
+
+    <section>
+        <h2>Non Static</h2>
+        <pap-codeblock class="non-static">
+            <style>
+                pap-codeblock.non-static {
+                    &::part(primary) {
+                        position: relative;
+                        min-height: 20rem;
+                        display: grid;
+
+                        grid-template-rows: auto 1fr auto;
+                        grid-template-columns: auto 1fr auto;
+                    }
+
+                    .center {
+                        grid-column: 2;
+                        grid-row: 2;
+                    }
+
+                    #drawer-right-non {
+                        grid-column: 3;
+                        grid-row: 1/4;
+                    }
+
+                    #drawer-left-non {
+                        grid-column: 1;
+                        grid-row: 1/4;
+                    }
+
+                    #drawer-top-non {
+                        grid-row: 1;
+                        grid-column: 1/4;
+                    }
+
+                    #drawer-bottom-non {
+                        grid-row: 3;
+                        grid-column: 1/4;
+                    }
+                }
+            </style>
+
+            <pap-drawer id="drawer-right-non" aria-label="Right drawer">
+                <p>Right drawer content</p>
+                <button commandfor="drawer-right-non" command="close">Close</button>
+            </pap-drawer>
+            <pap-drawer id="drawer-left-non" placement="left" aria-label="Left drawer">
+                <p>Left drawer content</p>
+                <button commandfor="drawer-left-non" command="close">Close</button>
+            </pap-drawer>
+            <pap-drawer id="drawer-top-non" placement="top" aria-label="Top drawer">
+                <p>Top drawer content</p>
+                <button commandfor="drawer-top-non" command="close">Close</button>
+            </pap-drawer>
+            <pap-drawer id="drawer-bottom-non" placement="bottom" aria-label="Bottom drawer">
+                <p>Bottom drawer content</p>
+                <button commandfor="drawer-bottom-non" command="close">Close</button>
+            </pap-drawer>
+
+            <div class="center">
+                <!-- Right (default) -->
+                <button commandfor="drawer-right-non" command="toggle">Open Right</button>
+
+                <!-- Left -->
+                <button commandfor="drawer-left-non" command="toggle">Open Left</button>
+
+                <!-- Top -->
+                <button commandfor="drawer-top-non" command="toggle">Open Top</button>
+
+                <!-- Bottom -->
+                <button commandfor="drawer-bottom-non" command="toggle">Open Bottom</button>
+            </div>
+        </pap-codeblock>
+    </section>
+</body>
+
+</html>

--- a/packages/web/design-system/molecules/drawer/views/experiment/main.js
+++ b/packages/web/design-system/molecules/drawer/views/experiment/main.js
@@ -1,0 +1,14 @@
+// core
+import { translator } from '@papit/translator';
+import "@papit/codeblock";
+
+// component
+import '@papit/drawer';
+
+window.onload = () => {
+    console.log('[demo]: window loaded');
+
+    translator.add({ id: "en", url: "/en.json" });
+    translator.change("en");
+}
+

--- a/packages/web/design-system/molecules/drawer/views/experiment/public/translations/en.json
+++ b/packages/web/design-system/molecules/drawer/views/experiment/public/translations/en.json
@@ -1,0 +1,7 @@
+{
+  "meta": {
+    "region": "GB",
+    "language": "en-UK"
+  },
+  "drawer": "drawer"
+}

--- a/packages/web/design-system/molecules/drawer/views/experiment/style.css
+++ b/packages/web/design-system/molecules/drawer/views/experiment/style.css
@@ -1,0 +1,28 @@
+@import "@papit/theme";
+
+body {
+    background-color: var(--background, light-dark(oklch(96% 0 0), oklch(17% 0 0)));
+    color: var(--text, light-dark(oklch(10% 0 0), oklch(95% 0 0)));
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4, 16px);
+
+    padding-block: 5rem;
+
+    h1 {
+        max-width: 1200px;
+        margin-inline: auto;
+        width: 100%;
+    }
+
+    section {
+        max-width: 1200px;
+        margin-inline: auto;
+        width: 100%;
+        box-sizing: border-box;
+        padding: 1rem 2rem;
+        border-radius: 1rem;
+        border: 1px solid light-dark(oklch(88% 0.01 264), oklch(28% 0.015 264));
+        background-color: var(--background-light, light-dark(oklch(99% 0 0), oklch(22% 0 0)));
+    }
+}

--- a/packages/web/design-system/molecules/drawer/views/tsconfig.json
+++ b/packages/web/design-system/molecules/drawer/views/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ".."
+    },
+    "include": [
+        "."
+    ]
+}

--- a/packages/web/design-system/molecules/theme-picker/package.json
+++ b/packages/web/design-system/molecules/theme-picker/package.json
@@ -1,88 +1,88 @@
 {
-    "name": "@papit/theme-picker",
-    "description": "A simple yet elegant answer to a theme picker, light dark and system with powerful yet simple control",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "theme-picker"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/molecules/theme-picker",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/design-system/molecules/theme-picker"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/icon": "0.1.5",
-        "@papit/menu": "0.0.6",
-        "@papit/tooltip": "0.0.6",
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@papit/theme": "0.0.2",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6",
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "theme-picker",
-        "htmlprefix": "pap",
-        "components": {
-            "theme-picker": {
-                "className": "ThemePicker",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/theme-picker",
+  "description": "A simple yet elegant answer to a theme picker, light dark and system with powerful yet simple control",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "theme-picker"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/design-system/molecules/theme-picker",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/design-system/molecules/theme-picker"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/icon": "0.1.5",
+    "@papit/menu": "0.0.6",
+    "@papit/tooltip": "0.0.6",
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@papit/theme": "0.0.2",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7",
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "theme-picker",
+    "htmlprefix": "pap",
+    "components": {
+      "theme-picker": {
+        "className": "ThemePicker",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/web/engines/web-component/package.json
+++ b/packages/web/engines/web-component/package.json
@@ -1,83 +1,83 @@
 {
-    "name": "@papit/web-component",
-    "description": "the root component for @papit web components, this package deals with all the heavy lifting such as reactive rendering, properties etc",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "web-component"
-    ],
-    "version": "0.0.6",
-    "scripts": {
-        "build": "npx @papit/build -- --error --ancestors",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts $@",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit -- --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/design-system/web-component",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/design-system/web-component"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "devDependencies": {
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "@papit/arguments": "0.0.1",
-        "@papit/information": "0.0.6",
-        "@papit/translator": "0.1.0",
-        "@papit/codeblock": "0.1.6",
-        "typescript": "5.9.3"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "web-component",
-        "htmlprefix": "pap",
-        "components": {
-            "web-component": {
-                "className": "WebComponent",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.0.6"
+  "name": "@papit/web-component",
+  "description": "the root component for @papit web components, this package deals with all the heavy lifting such as reactive rendering, properties etc",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "web-component"
+  ],
+  "version": "0.0.6",
+  "scripts": {
+    "build": "npx @papit/build -- --error --ancestors",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts $@",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit -- --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/design-system/web-component",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/design-system/web-component"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "@papit/arguments": "0.0.1",
+    "@papit/information": "0.0.7",
+    "@papit/translator": "0.1.0",
+    "@papit/codeblock": "0.1.7",
+    "typescript": "5.9.3"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "web-component",
+    "htmlprefix": "pap",
+    "components": {
+      "web-component": {
+        "className": "WebComponent",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.0.6"
 }

--- a/packages/web/tools/router/package.json
+++ b/packages/web/tools/router/package.json
@@ -1,85 +1,85 @@
 {
-    "name": "@papit/router",
-    "description": "Elegant answer for routing SPA and MPA, any element can help to define paths with variables and fallback values",
-    "keywords": [
-        "papit",
-        "web-component",
-        "typescript",
-        "router"
-    ],
-    "version": "0.1.2",
-    "scripts": {
-        "build": "npx @papit/build --error",
-        "watch": "tsc -w",
-        "start": "npx @papit/server --info --live",
-        "test": "npx playwright test -c tests/playwright.config.ts",
-        "preversion": "papit-version",
-        "postversion": "papit-version",
-        "component": "npm create @papit --component",
-        "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
-        "test:chrome": "npm test -- --project=chromium",
-        "build:react": "bash ./bin/_utils/react.sh"
-    },
-    "main": "./lib/bundle.js",
-    "types": "./lib/bundle.d.ts",
-    "type": "module",
-    "files": [
-        "asset/",
-        "lib/"
-    ],
-    "exports": {
-        ".": {
-            "import": "./lib/bundle.js",
-            "types": "./lib/bundle.d.ts"
-        }
-    },
-    "author": "henry",
-    "private": false,
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "license": "LicenseRef-Papit-1.0",
-    "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/tools/router",
-    "bugs": {
-        "url": "https://github.com/onkelhoy/papit/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/onkelhoy/papit.git",
-        "directory": "packages/web/tools/router"
-    },
-    "sideEffects": true,
-    "engines": {
-        "node": ">=18"
-    },
-    "dependencies": {
-        "@papit/web-component": "0.0.6"
-    },
-    "devDependencies": {
-        "@playwright/test": "1.58.0",
-        "playwright": "1.58.0",
-        "typescript": "5.9.3",
-        "@papit/theme": "*",
-        "@papit/translator": "*",
-        "@papit/codeblock": "0.1.6"
-    },
-    "browserslist": [
-        "defaults",
-        "not IE 11",
-        "not dead"
-    ],
-    "papit": {
-        "publish": true,
-        "type": "web-component",
-        "main": "router",
-        "htmlprefix": "pap",
-        "components": {
-            "router": {
-                "className": "Router",
-                "htmlprefix": "pap"
-            }
-        }
-    },
-    "remoteVersion": "0.1.2"
+  "name": "@papit/router",
+  "description": "Elegant answer for routing SPA and MPA, any element can help to define paths with variables and fallback values",
+  "keywords": [
+    "papit",
+    "web-component",
+    "typescript",
+    "router"
+  ],
+  "version": "0.1.2",
+  "scripts": {
+    "build": "npx @papit/build --error",
+    "watch": "tsc -w",
+    "start": "npx @papit/server --info --live",
+    "test": "npx playwright test -c tests/playwright.config.ts",
+    "preversion": "papit-version",
+    "postversion": "papit-version",
+    "component": "npm create @papit --component",
+    "test:update-snapshots": "npx playwright test --update-snapshots -c tests/playwright.config.ts",
+    "test:chrome": "npm test -- --project=chromium",
+    "build:react": "bash ./bin/_utils/react.sh"
+  },
+  "main": "./lib/bundle.js",
+  "types": "./lib/bundle.d.ts",
+  "type": "module",
+  "files": [
+    "asset/",
+    "lib/"
+  ],
+  "exports": {
+    ".": {
+      "import": "./lib/bundle.js",
+      "types": "./lib/bundle.d.ts"
+    }
+  },
+  "author": "henry",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "LicenseRef-Papit-1.0",
+  "homepage": "https://github.com/onkelhoy/papit/tree/main/packages/web/tools/router",
+  "bugs": {
+    "url": "https://github.com/onkelhoy/papit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onkelhoy/papit.git",
+    "directory": "packages/web/tools/router"
+  },
+  "sideEffects": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@papit/web-component": "0.0.6"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.0",
+    "playwright": "1.58.0",
+    "typescript": "5.9.3",
+    "@papit/theme": "*",
+    "@papit/translator": "*",
+    "@papit/codeblock": "0.1.7"
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "not dead"
+  ],
+  "papit": {
+    "publish": true,
+    "type": "web-component",
+    "main": "router",
+    "htmlprefix": "pap",
+    "components": {
+      "router": {
+        "className": "Router",
+        "htmlprefix": "pap"
+      }
+    }
+  },
+  "remoteVersion": "0.1.2"
 }


### PR DESCRIPTION
issue: #98

note: this addressed a major problem with @papit/information and now we have an improved @papit/data-structure graph model which we use in the information, now its more structured and thus can handle versioning better.

changelog:

- version: sync
- add: @papit/aside package
- delete: aside
- fix: memory cleanup for socket
- add: @papit/drawer package
- add: drawer logic
- add: drawer test
- fix: removed keyd error states - though a much deeper bug is located at webcompoent html rendering logic
- fix: switch drawer into full dialog mode
- fix: enhance wcag on codeblock
- fix: graph data structure
- version: codeblock patch
- version: data structure patch
- fix: drawer uses dialog and bumped up to molecule
- feat: tweak dialog to fit drawer case
- fix: drawer logic
- fix: dialog readme + jsdoc
- fix: drawer readme + jsdoc
- version: dialog patch